### PR TITLE
add ghcr.io docker image registry

### DIFF
--- a/.github/workflows/docker-publish-canary.yml
+++ b/.github/workflows/docker-publish-canary.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout
@@ -19,7 +22,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: moonrailgun/tianji
+          images: |
+            moonrailgun/tianji
+            ghcr.io/moonrailgun/tianji
           tags: |
             type=sha
       - name: Login to DockerHub
@@ -28,6 +33,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log into ghcr.io registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout
@@ -22,7 +25,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: moonrailgun/tianji
+          images: |
+            moonrailgun/tianji
+            ghcr.io/moonrailgun/tianji
           tags: |
             type=semver,pattern={{version}}
       - name: Login to DockerHub
@@ -31,6 +36,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log into ghcr.io registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push


### PR DESCRIPTION
Docker hub artificially limits pull requests for all users who aren't paid. https://docs.docker.com/docker-hub/download-rate-limit
 (100 for not logged-in users across *all* images pulls for the IP)

And it never hurts to have a second point of images. Especially considering you are already storing your code on GitHub, so having the images here is helpful. 

This PR will use your existing credentials to push an image to docker hub + GitHub packages and will list it on your main code page for https://github.com/msgbyte/tianji. No extra work should be needed.