### PR TITLE
Adding one-click deploy buttons to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ Direct update  `src/client/public/locales`
 `Tianji` is open source with `Apache 2.0` license.
 
 And its inspired by `umami` license which under `MIT` and `uptime-kuma` which under `MIT` license too
+
+### One-Click Deployment
+
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=270)
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/msgbyte/tianji)


### PR DESCRIPTION
Adding section enabling community access to one-click deployment template buttons for self-hosted options