### PR TITLE
docs: fix edit page url

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -49,7 +49,7 @@ const config: Config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/docs',
-          editUrl: 'https://github.com/msgbyte/tianji/tree/main/website/',
+          editUrl: 'https://github.com/msgbyte/tianji/tree/master/website/',
         },
         theme: {
           customCss: [


### PR DESCRIPTION
The edit page link on the doc pages point to wrong page. main -> master