### PR TITLE
fix: UTC Date Handling for Public Status Pages

### DIFF
--- a/src/server/model/monitor/index.ts
+++ b/src/server/model/monitor/index.ts
@@ -82,7 +82,7 @@ export async function getMonitorSummaryWithDay(
 
   const list = await prisma.$queryRaw<MonitorSummaryItem[]>`
     SELECT
-      DATE("createdAt") AS day,
+      TO_CHAR(DATE("createdAt"), 'YYYY-MM-DD') AS day,
       COUNT(1) AS total_count,
       SUM(CASE WHEN "value" >= 0 THEN 1 ELSE 0 END) AS up_count,
       (SUM(CASE WHEN "value" >= 0 THEN 1 ELSE 0 END) * 100.0 / COUNT(1)) AS up_rate


### PR DESCRIPTION
Prisma appears to automatically casts dates to UTC by default, which can lead to inconsistencies in date display, especially when working across timezones. By formatting the date as a string within the query, we can prevent Prisma from applying this UTC transformation.

**Before**
Dates were output in UTC format:
``2024-10-29T00:00:00.000Z``
**After**
Dates are now output in the intended local format:
``2024-10-29``

**Resolved Issue**
This discrepancy was noticed when viewing public status pages: data from 10-29 was sent under the date 10-28, even though the workspace and database share the same timezone settings. This PR ensures the dates are consistent with the workspace timezone configuration by removing the UTC cast.

**Note**
This only fixes the function used by the public status page, and I am unsure if this same issue exists elsewhere.