### PR TITLE
Fix number casting issue

### DIFF
--- a/src/server/model/monitor/index.ts
+++ b/src/server/model/monitor/index.ts
@@ -90,7 +90,7 @@ export async function getMonitorSummaryWithDay(
       "MonitorData"
     WHERE
       "monitorId" = ${monitorId} AND
-      "createdAt" >= CURRENT_DATE - INTERVAL '${beforeDay} days'
+      "createdAt" >= CURRENT_DATE - INTERVAL '1 day' * ${beforeDay}
     GROUP BY
       DATE("createdAt")
     ORDER BY


### PR DESCRIPTION
Previously, the query only returned the last 3 days instead of 30. This fix ensures the interval is applied correctly, retrieving data for the full 30-day period when using the ``getMonitorSummaryWithDay`` function.

**Before**
![Screenshot (1500)](https://github.com/user-attachments/assets/14d4feb6-fbd2-4a09-bd3a-f31668aa8279)

**After**
![Screenshot (1501)](https://github.com/user-attachments/assets/2923b812-08e3-48b7-964a-f8fb8b3003bf)
