### PR TITLE
Add cryptography because of Simple Push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY --from=static /app/tianji/src/server/public /app/tianji/src/server/public
 
 RUN pnpm build:server
 
-RUN pip install apprise --break-system-packages
+RUN pip install apprise cryptography --break-system-packages
 
 RUN rm -rf ./src/client
 RUN rm -rf ./website


### PR DESCRIPTION
SimplePush.io needs cryptography lib otherwise Apprise returns not enabled for your system.

Could be a quick win to enable SimplePush as it's basically installed and set-up within 10 seconds.

SimplePush is downloading an app, and using this apprise url: `spush://<your-secret-key>?event=Monitoring`. Very simple to use.