### PR TITLE
Make timezone customized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN cd reporter && go build .
 # The current Chromium version in Alpine 3.20 is causing timeout issues with Puppeteer. Downgrading to Alpine 3.19 fixes the issue. See #11640, #12637, #12189
 FROM node:20-alpine3.19 AS base
 
+ENV TZ=Asia/Shanghai
+
 RUN npm install -g pnpm@9.7.1
 
 # For apprise
@@ -24,7 +26,9 @@ RUN apk upgrade --no-cache --available \
       font-noto-emoji \
     && apk add --no-cache \
       --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-      font-wqy-zenhei
+      font-wqy-zenhei \
+    && apk add --no-cache tzdata \
+    && ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && echo "$TZ" > /etc/timezone
 
 # For zeromq
 RUN apk add --update --no-cache curl cmake


### PR DESCRIPTION
Problem:

Currently, Docker images built on Alpine lack the timezone package: tzdata.  Upon startup, they can only operate in UTC time and cannot be customized with user-specified timezones.

Solution:

- Install tzdata during image build.
- Default to the Shanghai timezone (TZ=Asia/Shanghai).
- Allow users to customize other timezones via environment variables.