### PR TITLE
docs: Add ClawCloud Run Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,5 @@ And its inspired by `umami` license which under `MIT` and `uptime-kuma` which un
 [![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=270)
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/msgbyte/tianji)
+
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=TNW6NVWTLHPQ&openapp=system-fastdeploy%3FtemplateName%3Dtianji)


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code in the deployment link is only for anonymous traffic analytics to help us improve our platform. If you’d like to use your own code, simply sign up on ClawCloud Run and replace it in seconds.