### PR TITLE
chore: fix typos, env variable name and improve tracker test

### DIFF
--- a/packages/client-sdk/src/tracker.spec.ts
+++ b/packages/client-sdk/src/tracker.spec.ts
@@ -8,7 +8,7 @@ describe('initTianjiTracker', () => {
   });
 
   test('simple', async () => {
-    await initTianjiTracker({
+    const script = await initTianjiTracker({
       url: 'https://example.com',
       websiteId: 'fooo',
     });
@@ -20,6 +20,8 @@ describe('initTianjiTracker', () => {
     expect(scriptDoms[0].dataset).toEqual({
       websiteId: 'fooo',
     });
+    expect(script).toBe(scriptDoms[0]);
+    expect(script.parentElement).toBe(document.head);
   });
 
   test('customTrackerName', async () => {

--- a/src/server/utils/env.ts
+++ b/src/server/utils/env.ts
@@ -49,7 +49,7 @@ export const env = {
       // Reference: https://authjs.dev/guides/configuring-oauth-providers
       name: process.env.AUTH_CUSTOM_NAME || 'Custom',
       type: process.env.AUTH_CUSTOM_TYPE || 'oidc', // or oauth
-      issuer: process.env.AUTH_CUSTOM_ISSUR,
+      issuer: process.env.AUTH_CUSTOM_ISSUER,
       clientId: process.env.AUTH_CUSTOM_ID,
       clientSecret: process.env.AUTH_CUSTOM_SECRET,
     },

--- a/website/docs/install/environment.md
+++ b/website/docs/install/environment.md
@@ -56,7 +56,7 @@ Tianji supports various environment variables to customize its behavior. You can
 | `AUTH_CUSTOM_SECRET` | Custom OAuth/OIDC client secret | - | `your-custom-client-secret` |
 | `AUTH_CUSTOM_NAME` | Custom provider name | `Custom` | `Enterprise SSO` |
 | `AUTH_CUSTOM_TYPE` | Authentication type | `oidc` | `oauth` |
-| `AUTH_CUSTOM_ISSUR` | OIDC issuer URL | - | `https://auth.example.com` |
+| `AUTH_CUSTOM_ISSUER` | OIDC issuer URL | - | `https://auth.example.com` |
 
 ## AI Features
 

--- a/website/docs/server-status/server-status-reporter.md
+++ b/website/docs/server-status/server-status-reporter.md
@@ -40,10 +40,10 @@ its will auto download reporter and create linux service in your machine. so its
 
 if you wanna uninstall reporter service, you can use this command like:
 ```bash
-curl -o- https://tianji.exmaple.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
+curl -o- https://tianji.example.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
 ``` 
 
-major change is append `-s uninstall` after your install command.
+The main change is to append `-s uninstall` to your install command.
 
 ## Q&A
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/install/environment.md
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/install/environment.md
@@ -56,7 +56,7 @@ Tianji unterstützt verschiedene Umgebungsvariablen, um sein Verhalten anzupasse
 | `AUTH_CUSTOM_SECRET` | Benutzerdefiniertes OAuth/OIDC-Client-Geheimnis | - | `your-custom-client-secret` |
 | `AUTH_CUSTOM_NAME` | Benutzerdefinierter Anbietername | `Custom` | `Enterprise SSO` |
 | `AUTH_CUSTOM_TYPE` | Authentifizierungstyp | `oidc` | `oauth` |
-| `AUTH_CUSTOM_ISSUR` | OIDC-Herausgeber-URL | - | `https://auth.example.com` |
+| `AUTH_CUSTOM_ISSUER` | OIDC-Herausgeber-URL | - | `https://auth.example.com` |
 
 ## KI-Funktionen
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/install/environment.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/install/environment.md
@@ -56,7 +56,7 @@ Tianji prend en charge diverses variables d'environnement pour personnaliser son
 | `AUTH_CUSTOM_SECRET` | Secret client OAuth/OIDC personnalisée | - | `your-custom-client-secret` |
 | `AUTH_CUSTOM_NAME` | Nom du fournisseur personnalisé | `Custom` | `Enterprise SSO` |
 | `AUTH_CUSTOM_TYPE` | Type d'authentification | `oidc` | `oauth` |
-| `AUTH_CUSTOM_ISSUR` | URL de l'émetteur OIDC | - | `https://auth.example.com` |
+| `AUTH_CUSTOM_ISSUER` | URL de l'émetteur OIDC | - | `https://auth.example.com` |
 
 ## Fonctionnalités AI
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/server-status/server-status-reporter.md
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/server-status/server-status-reporter.md
@@ -40,10 +40,10 @@ Il téléchargera automatiquement le rapporteur et créera un service Linux sur 
 
 Si vous souhaitez désinstaller le service de rapporteur, vous pouvez utiliser cette commande :
 ```bash
-curl -o- https://tianji.exmaple.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
+curl -o- https://tianji.example.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
 ```
 
-Le changement majeur consiste à ajouter `-s uninstall` après votre commande d'installation.
+Le changement principal consiste à ajouter `-s uninstall` à votre commande d'installation.
 
 ## Q&R
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/install/environment.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/install/environment.md
@@ -57,7 +57,7 @@ Tianjiは、様々な環境変数をサポートしており、その動作を�
 | `AUTH_CUSTOM_SECRET` | カスタムOAuth/OIDCクライアントシークレット | - | `your-custom-client-secret` |
 | `AUTH_CUSTOM_NAME` | カスタムプロバイダーの名前 | `Custom` | `Enterprise SSO` |
 | `AUTH_CUSTOM_TYPE` | 認証タイプ | `oidc` | `oauth` |
-| `AUTH_CUSTOM_ISSUR` | OIDC発行者URL | - | `https://auth.example.com` |
+| `AUTH_CUSTOM_ISSUER` | OIDC発行者URL | - | `https://auth.example.com` |
 
 ## AI機能
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/server-status/server-status-reporter.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/server-status/server-status-reporter.md
@@ -40,7 +40,7 @@ tianji-reporterの使用法:
 
 レポータサービスをアンインストールしたい場合は、次のコマンドを使用できます：
 ```bash
-curl -o- https://tianji.exmaple.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
+curl -o- https://tianji.example.com/serverStatus/xxxxxxxxxxxxxxxxxxx/install.sh?url=https://tianji.example.com | sudo bash -s uninstall
 ``` 
 
 主要な変更点は、インストールコマンドの後に `-s uninstall` を追加することです。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/install/environment.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/install/environment.md
@@ -56,7 +56,7 @@ Tianji 支持通过各种环境变量来自定义其行为。您可以在 docker
 | `AUTH_CUSTOM_SECRET` | 自定义 OAuth/OIDC 客户端密钥 | - | `your-custom-client-secret` |
 | `AUTH_CUSTOM_NAME` | 自定义提供者名称 | `Custom` | `Enterprise SSO` |
 | `AUTH_CUSTOM_TYPE` | 认证类型 | `oidc` | `oauth` |
-| `AUTH_CUSTOM_ISSUR` | OIDC 发行者 URL | - | `https://auth.example.com` |
+| `AUTH_CUSTOM_ISSUER` | OIDC 发行者 URL | - | `https://auth.example.com` |
 
 ## AI 特性
 


### PR DESCRIPTION
## Summary
- fix exmaple -> example in server status docs
- rename AUTH_CUSTOM_ISSUR -> AUTH_CUSTOM_ISSUER throughout env and docs
- clarify uninstall instructions in docs
- enhance tracker.spec to verify returned script element

## Testing
- `pnpm test` *(fails: fetch to registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ab00c9cb88323bea946583c02faa7