### PR TITLE
Implement server status history

### DIFF
--- a/src/server/trpc/routers/serverStatus.ts
+++ b/src/server/trpc/routers/serverStatus.ts
@@ -1,5 +1,9 @@
-import { router, workspaceAdminProcedure } from '../trpc.js';
-import { clearOfflineServerStatus } from '../../model/serverStatus.js';
+import { z } from 'zod';
+import { router, workspaceAdminProcedure, workspaceProcedure } from '../trpc.js';
+import {
+  clearOfflineServerStatus,
+  getServerStatusHistory,
+} from '../../model/serverStatus.js';
 
 export const serverStatusRouter = router({
   clearOfflineServerStatus: workspaceAdminProcedure.mutation(
@@ -9,4 +13,27 @@ export const serverStatusRouter = router({
       return clearOfflineServerStatus(workspaceId);
     }
   ),
+  history: workspaceProcedure
+    .input(
+      z.object({
+        workspaceId: z.string().cuid2(),
+        name: z.string(),
+      })
+    )
+    .output(
+      z.array(
+        z.object({
+          workspaceId: z.string(),
+          name: z.string(),
+          hostname: z.string(),
+          timeout: z.number().optional(),
+          updatedAt: z.number(),
+          payload: z.any(),
+        })
+      )
+    )
+    .query(async ({ input }) => {
+      const { workspaceId, name } = input;
+      return getServerStatusHistory(workspaceId, name);
+    }),
 });


### PR DESCRIPTION
## Summary
- cache last 20 server status records on the server
- expose history via `serverStatus.history` TRPC query
- show history chart in server detail view

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685aba848fe08323ba0dfae53851ead4