### PR TITLE
feat: add detail toggle for status page monitors

### DIFF
--- a/src/client/components/monitor/StatusPage/Body.tsx
+++ b/src/client/components/monitor/StatusPage/Body.tsx
@@ -1,5 +1,5 @@
 import { AppRouterOutput, trpc } from '@/api/trpc';
-import React, { useMemo, useReducer } from 'react';
+import React, { useMemo, useReducer, useCallback } from 'react';
 import { bodySchema } from './schema';
 import { Empty } from 'antd';
 import { Separator } from '@/components/ui/separator';
@@ -63,6 +63,7 @@ export const StatusPageBody: React.FC<StatusPageBodyProps> = React.memo(
                         workspaceId={props.workspaceId}
                         monitorId={item.id}
                         showCurrent={item.showCurrent ?? false}
+                        showDetail={item.showDetail ?? true}
                       />
                     </React.Fragment>
                   );
@@ -82,8 +83,10 @@ StatusPageBody.displayName = 'StatusPageBody';
 export const StatusItemMonitor: React.FC<{
   monitorId: string;
   showCurrent: boolean;
+  showDetail?: boolean;
   workspaceId: string;
 }> = React.memo((props) => {
+  const { showDetail = true } = props;
   const updateLastUpdatedAt = useStatusPageStore(
     (state) => state.updateLastUpdatedAt
   );
@@ -114,6 +117,11 @@ export const StatusItemMonitor: React.FC<{
   });
 
   const [showChart, toggleShowChart] = useReducer((state) => !state, false);
+  const handleToggleChart = useCallback(() => {
+    if (showDetail) {
+      toggleShowChart();
+    }
+  }, [showDetail]);
 
   const { summaryStatus, summaryPercent } = useMemo(() => {
     let upCount = 0;
@@ -141,7 +149,7 @@ export const StatusItemMonitor: React.FC<{
         className={cn(
           'mb-1 flex cursor-pointer items-center overflow-hidden rounded-lg bg-green-500 bg-opacity-0 px-4 py-3 hover:bg-opacity-10'
         )}
-        onClick={toggleShowChart}
+        onClick={handleToggleChart}
       >
         <div>
           <span
@@ -185,7 +193,7 @@ export const StatusItemMonitor: React.FC<{
         </div>
       </div>
 
-      {showChart && (
+      {showChart && showDetail && (
         <MonitorPublicDataChart
           workspaceId={props.workspaceId}
           monitorId={props.monitorId}

--- a/src/client/components/monitor/StatusPage/EditForm.tsx
+++ b/src/client/components/monitor/StatusPage/EditForm.tsx
@@ -50,6 +50,7 @@ const editFormSchema = z.object({
     z.object({
       id: z.string(),
       showCurrent: z.boolean().default(false).optional(),
+      showDetail: z.boolean().default(true).optional(),
     })
   ),
 });
@@ -264,6 +265,22 @@ export const MonitorStatusPageEditForm: React.FC<MonitorStatusPageEditFormProps>
                             {t('Show Latest Value')}
                           </span>
 
+                          <Controller
+                            control={form.control}
+                            name={`monitorList.${i}.showDetail`}
+                            render={({ field }) => (
+                              <Switch
+                                className="ml-4"
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            )}
+                          />
+
+                          <span className="ml-1 flex-1 align-middle text-sm">
+                            {t('Show Detail')}
+                          </span>
+
                           <LuCircleMinus
                             className="cursor-pointer text-lg"
                             onClick={() => remove(i)}
@@ -282,6 +299,7 @@ export const MonitorStatusPageEditForm: React.FC<MonitorStatusPageEditFormProps>
                       append({
                         id: '',
                         showCurrent: false,
+                        showDetail: true,
                       })
                     }
                     style={{ width: '60%' }}

--- a/src/client/components/monitor/StatusPage/ServiceList.tsx
+++ b/src/client/components/monitor/StatusPage/ServiceList.tsx
@@ -60,6 +60,7 @@ export const MonitorStatusPageServiceList: React.FC<MonitorStatusPageServiceList
           id: '',
           type: 'monitor',
           showCurrent: false,
+          showDetail: true,
         },
       ] as MonitorStatusPageServiceItem[];
 
@@ -219,6 +220,23 @@ export const MonitorStatusPageServiceList: React.FC<MonitorStatusPageServiceList
 
                       <span className="ml-1 flex-1 align-middle text-sm">
                         {t('Show Latest Value')}
+                      </span>
+
+                      <Switch
+                        className="ml-4"
+                        checked={item.showDetail ?? true}
+                        onCheckedChange={(val) =>
+                          handleUpdateItem(
+                            group.key,
+                            item.key,
+                            'showDetail',
+                            val
+                          )
+                        }
+                      />
+
+                      <span className="ml-1 flex-1 align-middle text-sm">
+                        {t('Show Detail')}
                       </span>
 
                       <LuCircleMinus

--- a/src/client/components/monitor/StatusPage/Services.tsx
+++ b/src/client/components/monitor/StatusPage/Services.tsx
@@ -11,6 +11,7 @@ interface StatusPageServicesProps {
   monitorList: {
     id: string;
     showCurrent?: boolean;
+    showDetail?: boolean;
   }[];
 }
 /**

--- a/src/client/components/monitor/StatusPage/schema.ts
+++ b/src/client/components/monitor/StatusPage/schema.ts
@@ -5,6 +5,7 @@ export const leafItemSchema = z.object({
   id: z.string(),
   type: z.enum(['monitor']),
   showCurrent: z.boolean().default(false).optional(),
+  showDetail: z.boolean().default(true).optional(),
 });
 
 export const groupItemSchema = z.object({

--- a/src/client/public/locales/de-DE/translation.json
+++ b/src/client/public/locales/de-DE/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Finnland",
   "k3a585220": "Guam",
+  "k3a717a2b": "Show Detail",
   "k3aa52f41": "am Tag",
   "k3aad2c64": "Uruguay",
   "k3ab433c7": "Tonga",

--- a/src/client/public/locales/en/translation.json
+++ b/src/client/public/locales/en/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "No website has been added. You can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Finland",
   "k3a585220": "Guam",
+  "k3a717a2b": "Show Detail",
   "k3aa52f41": "in Day",
   "k3aad2c64": "Uruguay",
   "k3ab433c7": "Tonga",

--- a/src/client/public/locales/fr-FR/translation.json
+++ b/src/client/public/locales/fr-FR/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Finlande",
   "k3a585220": "Guam",
+  "k3a717a2b": "Afficher le détail",
   "k3aa52f41": "en jour",
   "k3aad2c64": "Uruguay",
   "k3ab433c7": "Tonga",

--- a/src/client/public/locales/ja-JP/translation.json
+++ b/src/client/public/locales/ja-JP/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "フィンランド",
   "k3a585220": "グアム",
+  "k3a717a2b": "詳細を表示",
   "k3aa52f41": "日中",
   "k3aad2c64": "ウルグアイ",
   "k3ab433c7": "トンガ",

--- a/src/client/public/locales/pl-PL/translation.json
+++ b/src/client/public/locales/pl-PL/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Finlandia",
   "k3a585220": "Guam",
+  "k3a717a2b": "Pokaż szczegóły",
   "k3aa52f41": "w dzień",
   "k3aad2c64": "Urugwaj",
   "k3ab433c7": "Tonga",

--- a/src/client/public/locales/pt-PT/translation.json
+++ b/src/client/public/locales/pt-PT/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Finlândia",
   "k3a585220": "Guam",
+  "k3a717a2b": "Mostrar Detalhe",
   "k3aa52f41": "em Dia",
   "k3aad2c64": "Uruguai",
   "k3ab433c7": "Tonga",

--- a/src/client/public/locales/ru-RU/translation.json
+++ b/src/client/public/locales/ru-RU/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "Финляндия",
   "k3a585220": "Гуам",
+  "k3a717a2b": "Показать детали",
   "k3aa52f41": "в день",
   "k3aad2c64": "Уругвай",
   "k3ab433c7": "Тонга",

--- a/src/client/public/locales/zh-CN/translation.json
+++ b/src/client/public/locales/zh-CN/translation.json
@@ -178,6 +178,7 @@
   "k38b90a03": "Not any website has been added, you can add your website and integrate with Tianji to get more information.",
   "k3a0a0247": "芬兰",
   "k3a585220": "关岛",
+  "k3a717a2b": "显示详情",
   "k3aa52f41": "在一天内",
   "k3aad2c64": "乌拉圭",
   "k3ab433c7": "汤加",

--- a/src/server/prisma/zod/schemas/index.ts
+++ b/src/server/prisma/zod/schemas/index.ts
@@ -6,6 +6,7 @@ export const MonitorStatusPageListSchema = z.array(
   z.object({
     id: z.string(),
     showCurrent: z.boolean().default(false).optional(),
+    showDetail: z.boolean().default(true).optional(),
   })
 );
 


### PR DESCRIPTION
## Summary
- allow status page monitor items to configure whether visitors can open detail charts
- wire showDetail option through page editor and service list
- translate Show Detail
- update schema for new field

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685c61f179ac8323aa4a55d5172dc861