### PR TITLE
fix: custom domain redirect

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -126,7 +126,7 @@ if (env.allowOpenapi) {
 
 // Custom domain: only for root path so /p/:slug and /status/:slug are not intercepted
 app.use('/*', async (req, res, next) => {
-  if (req.method === 'GET' && req.accepts('html')) {
+  if (req.method === 'GET' && req.originalUrl === '/' && req.accepts('html')) {
     const customDomain = customDomainManager.findPageDomain(req.hostname);
     if (customDomain) {
       if (customDomain.type === 'static') {


### PR DESCRIPTION
Fixed custom-domain routing to only trigger on the root path (/) for HTML GET requests.
This prevents the custom-domain middleware from intercepting other routes (such as status or static page paths), ensuring normal route handling and correct behavior after build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom domain routing to properly handle requests to specific paths, ensuring `/p/:slug` and `/status/:slug` routes work correctly on custom domains instead of being incorrectly intercepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->