### PR TITLE
docs(readme): add docker compose setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ It's good to specialize in one thing, if we are experts in related abilities we 
 
 ![](./website/static/img/preview/6.png)
 
+## Setup
+
+### Docker Compose
+
+Run the included Compose stack from the repository root:
+
+```bash
+docker compose up -d
+```
+
+This starts both the `tianji` application and its `postgres` database. The application is available at `http://localhost:12345` by default.
+
+### Environment
+
+For local source development, create the server environment file before starting the dev server:
+
+```bash
+cp .env.example src/server/.env
+```
+
+At minimum, configure `DATABASE_URL` with the PostgreSQL connection string used by the server, for example:
+
+```ini
+DATABASE_URL="postgresql://tianji:tianji@localhost:5432/tianji?schema=public"
+```
+
+`OPENAPI_KEY` is only needed for the translation auto-generation command below.
+
 ## Translation
 
 ### Add a new translation


### PR DESCRIPTION
## Background
Document the Docker Compose startup path and required local environment setup for new contributors.

## Changes
- Add a Setup section for running the included Docker Compose stack
- Document the default local application URL
- Explain how to create the server `.env` file for local source development
- Provide an example `DATABASE_URL`
- Clarify that `OPENAPI_KEY` is only required for translation auto-generation

## Testing
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for running the project locally with Docker Compose.
  * Documented the default application URL and startup services.
  * Added guidance for creating the development environment file and configuring the database connection.
  * Clarified when the OpenAPI key is required for translation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->