### PR TITLE
feat(ai-gateway): add connectivity testing

### DIFF
--- a/docs/superpowers/specs/2026-07-14-ai-gateway-connectivity-test-design.md
+++ b/docs/superpowers/specs/2026-07-14-ai-gateway-connectivity-test-design.md
@@ -1,0 +1,139 @@
+# AI Gateway Connectivity Test Design
+
+## Summary
+
+The AI Gateway edit page should let a workspace administrator test the current,
+unsaved custom gateway configuration before updating it. The test uses the same
+OpenAI-compatible upstream behavior as the AI Gateway `custom` route and sends a
+minimal non-streaming chat completion.
+
+The connection test is an administrative validation action. It does not save the
+form, update the gateway cache, or create AI Gateway usage logs.
+
+## Goals
+
+- Add a `Test Connection` action to the existing AI Gateway edit form.
+- Test the API key, custom base URL, and custom model name currently entered in
+  the form, including unsaved changes.
+- Use the custom OpenAI-compatible upstream path rather than a built-in provider
+  such as OpenAI, Anthropic, DeepSeek, or OpenRouter.
+- Select the first model returned by `/v1/models` when the custom model name is
+  empty.
+- Report a useful success or failure result without exposing the API key.
+
+## Non-Goals
+
+- Do not add the action to the AI Gateway creation page.
+- Do not save or temporarily persist form values during a test.
+- Do not add test requests to AI Gateway analytics or request logs.
+- Do not test the built-in provider-specific routes.
+- Do not modify translation JSON files under `src/client/public/locales`.
+
+## User Interface
+
+Extend `AIGatewayEditForm` with an optional connection-test callback. The edit
+route supplies the callback, while the creation route does not, so only the edit
+page renders the new action.
+
+Place an outline `Test Connection` button next to the existing `Update` button.
+The button uses `type="button"` so it cannot submit the update form. Clicking it
+validates the current form before starting the request. While the request is in
+progress, the button shows its loading state and cannot start a duplicate test.
+
+On success, show a toast that identifies the model used and the elapsed request
+time. On failure, show the upstream or validation error through the existing
+client error presentation. Testing must not reset the form or navigate away.
+
+## Server API
+
+Add an `aiGateway.testConnection` workspace-admin mutation. Its input contains:
+
+```ts
+{
+  workspaceId: string;
+  gatewayId: string;
+  modelApiKey: string;
+  customModelBaseUrl: string | null;
+  customModelName: string | null;
+}
+```
+
+The mutation verifies that `gatewayId` belongs to `workspaceId`, then invokes a
+focused custom-connectivity service with the transient input values. It returns:
+
+```ts
+{
+  model: string;
+  durationMs: number;
+}
+```
+
+This remains a tRPC-only administrative operation and does not expand the public
+AI Gateway HTTP API.
+
+## Custom Request Flow
+
+The connectivity service constructs an OpenAI client with the submitted API key
+and custom base URL, using the same client configuration semantics as
+`/api/ai/:workspaceId/:gatewayId/custom/v1/*`. It does not make an HTTP request
+back into Tianji's public custom route because that route intentionally reads the
+saved gateway configuration, which would ignore unsaved form values.
+
+The service selects a model as follows:
+
+1. Trim `customModelName`.
+2. If it is non-empty, use it directly and do not request the model list.
+3. If it is empty, call the upstream OpenAI-compatible `GET /v1/models` endpoint.
+4. Use the first returned model ID.
+5. If the upstream returns no models, fail with an explicit error instead of
+   sending an invalid completion request.
+
+After selecting the model, send one non-streaming chat completion containing a
+single user message, `Reply with OK.`, and `max_tokens: 1`. A successful upstream
+completion is sufficient; the test does not require the response text to equal
+`OK`.
+
+Configure the client with no automatic retries and a 15-second timeout for each
+upstream request. `durationMs` measures the complete model-selection and chat
+completion flow.
+
+## Validation And Error Handling
+
+- Apply the existing form URL validation before invoking the mutation.
+- Normalize empty optional strings to `null` at the route boundary.
+- Require `modelApiKey` for the UI connection test. Unlike a normal custom-route
+  request, this administrative action has no end-user authorization header to
+  use as a fallback upstream credential.
+- Preserve useful upstream authentication, model, network, and timeout messages
+  in the tRPC error shown to the administrator.
+- Never include the submitted API key in the response, logs, toast text, or
+  thrown error messages created by Tianji. Remove an exact key match from any
+  upstream error message before returning it.
+- Do not update gateway cache state regardless of success or failure.
+
+## Testing
+
+Server tests cover:
+
+- A supplied custom model name skips `/v1/models` and is used for the completion.
+- An empty custom model name requests `/v1/models` and uses the first model.
+- An empty model list produces an explicit failure.
+- The completion is non-streaming and uses a minimal request payload.
+- The tRPC mutation rejects a gateway outside the current workspace.
+- The mutation returns the selected model and elapsed time without returning the
+  API key.
+
+Client component tests cover:
+
+- The optional action is rendered on edit and omitted when no test callback is
+  supplied.
+- Clicking the action validates and passes the current unsaved form values.
+- The action does not call the update submit callback.
+- Loading and success/error feedback use the test mutation state without
+  resetting the form.
+
+## Rollout
+
+The change requires no database migration and does not alter existing gateway
+runtime behavior. Existing edit and create flows continue unchanged unless the
+administrator explicitly clicks `Test Connection`.

--- a/src/client/api/trpc.ts
+++ b/src/client/api/trpc.ts
@@ -22,6 +22,7 @@ export type AppRouterInput = inferRouterInputs<AppRouter>;
 export type AppRouterOutput = inferRouterOutputs<AppRouter>;
 
 const url = '/trpc';
+const sensitiveOperationPaths = new Set(['aiGateway.testConnection']);
 
 function headers() {
   const timezone = getUserTimezone();
@@ -36,9 +37,15 @@ function headers() {
 export const trpcClient = trpc.createClient({
   links: [
     loggerLink({
-      enabled: (opts) =>
-        (isDev && typeof window !== 'undefined') ||
-        (opts.direction === 'down' && opts.result instanceof Error),
+      enabled: (opts) => {
+        const { path } = opts as typeof opts & { path: string };
+
+        return (
+          !sensitiveOperationPaths.has(path) &&
+          ((isDev && typeof window !== 'undefined') ||
+            (opts.direction === 'down' && opts.result instanceof Error))
+        );
+      },
     }),
     splitLink({
       condition(op) {

--- a/src/client/components/aiGateway/AIGatewayEditForm.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayEditForm.component.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import {
+  AIGatewayEditForm,
+  type AIGatewayEditFormValues,
+} from './AIGatewayEditForm';
+
+vi.mock('@i18next-toolkit/react', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: React.forwardRef<
+    HTMLLabelElement,
+    React.LabelHTMLAttributes<HTMLLabelElement> & { optional?: boolean }
+  >(({ optional: _optional, ...props }, ref) => <label ref={ref} {...props} />),
+}));
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  CollapsibleContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('./AIGatewayStrategyEditor', () => ({
+  AIGatewayStrategyEditor: () => null,
+}));
+
+const defaultValues: AIGatewayEditFormValues = {
+  name: 'Gateway',
+  modelApiKey: 'sk-existing',
+  customModelBaseUrl: 'https://old.example.com/v1',
+  customModelName: 'old-model',
+  customModelStrategy: '',
+  customModelInputPrice: null,
+  customModelOutputPrice: null,
+};
+
+describe('AIGatewayEditForm connection test action', () => {
+  test('omits the action when no test callback is supplied', () => {
+    render(
+      <AIGatewayEditForm defaultValues={defaultValues} onSubmit={vi.fn()} />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Test Connection' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('passes current unsaved values without submitting or resetting', async () => {
+    const onSubmit = vi.fn(async () => undefined);
+    const onTestConnection = vi.fn();
+    render(
+      <AIGatewayEditForm
+        defaultValues={defaultValues}
+        onSubmit={onSubmit}
+        onTestConnection={onTestConnection}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Model API Key/), {
+      target: { value: 'sk-current' },
+    });
+    fireEvent.change(screen.getByLabelText(/Custom Model Base URL/), {
+      target: { value: 'https://current.example.com/v1' },
+    });
+    fireEvent.change(screen.getByLabelText(/Custom Model Name/), {
+      target: { value: 'current-model' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+    await waitFor(() => {
+      expect(onTestConnection).toHaveBeenCalledWith({
+        ...defaultValues,
+        modelApiKey: 'sk-current',
+        customModelBaseUrl: 'https://current.example.com/v1',
+        customModelName: 'current-model',
+      });
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue('current-model')).toBeInTheDocument();
+  });
+
+  test('requires an API key before invoking the test callback', async () => {
+    const onTestConnection = vi.fn();
+    render(
+      <AIGatewayEditForm
+        defaultValues={{ ...defaultValues, modelApiKey: '' }}
+        onSubmit={vi.fn(async () => undefined)}
+        onTestConnection={onTestConnection}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+    expect(
+      await screen.findByText('Model API Key is required')
+    ).toBeInTheDocument();
+    expect(onTestConnection).not.toHaveBeenCalled();
+  });
+
+  test('disables the action while the connection test is pending', () => {
+    render(
+      <AIGatewayEditForm
+        defaultValues={defaultValues}
+        onSubmit={vi.fn(async () => undefined)}
+        onTestConnection={vi.fn()}
+        isTestingConnection={true}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test Connection' })
+    ).toBeDisabled();
+  });
+});

--- a/src/client/components/aiGateway/AIGatewayEditForm.tsx
+++ b/src/client/components/aiGateway/AIGatewayEditForm.tsx
@@ -48,6 +48,8 @@ export type AIGatewayEditFormValues = z.infer<typeof addFormSchema>;
 interface AIGatewayEditFormProps {
   defaultValues?: AIGatewayEditFormValues;
   onSubmit: (values: AIGatewayEditFormValues) => Promise<void>;
+  onTestConnection?: (values: AIGatewayEditFormValues) => void;
+  isTestingConnection?: boolean;
 }
 export const AIGatewayEditForm: React.FC<AIGatewayEditFormProps> = React.memo(
   (props) => {
@@ -72,6 +74,25 @@ export const AIGatewayEditForm: React.FC<AIGatewayEditFormProps> = React.memo(
         form.reset();
       }
     );
+
+    const handleTestConnection = async () => {
+      const isValid = await form.trigger();
+      if (!isValid) {
+        return;
+      }
+
+      const values = form.getValues();
+      if (!values.modelApiKey?.trim()) {
+        form.setError('modelApiKey', {
+          type: 'manual',
+          message: 'Model API Key is required',
+        });
+        return;
+      }
+
+      props.onTestConnection?.({ ...values });
+    };
+
     return (
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-8">
@@ -292,10 +313,20 @@ export const AIGatewayEditForm: React.FC<AIGatewayEditFormProps> = React.memo(
               </Collapsible>
             </CardContent>
 
-            <CardFooter>
+            <CardFooter className="gap-2">
               <Button type="submit" loading={isLoading}>
                 {props.defaultValues ? t('Update') : t('Create')}
               </Button>
+              {props.onTestConnection && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  loading={props.isTestingConnection}
+                  onClick={handleTestConnection}
+                >
+                  {t('Test Connection')}
+                </Button>
+              )}
             </CardFooter>
           </Card>
         </form>

--- a/src/client/components/aiGateway/AIGatewayEditRoute.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayEditRoute.component.spec.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  testConnectionMutate: vi.fn(),
+  testConnectionOptions: { current: null as any },
+  toastSuccess: vi.fn(),
+  defaultErrorHandler: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute:
+    () =>
+    (options: Record<string, unknown>) => ({
+      ...options,
+      useParams: () => ({ gatewayId: 'gateway_1' }),
+    }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@i18next-toolkit/react', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: mocks.toastSuccess },
+}));
+
+vi.mock('@/utils/route', () => ({ routeAuthBeforeLoad: vi.fn() }));
+vi.mock('@/store/user', () => ({ useCurrentWorkspaceId: () => 'workspace_1' }));
+
+vi.mock('@/api/trpc', () => ({
+  defaultErrorHandler: mocks.defaultErrorHandler,
+  trpc: {
+    useUtils: () => ({ aiGateway: { all: { refetch: vi.fn() } } }),
+    aiGateway: {
+      info: {
+        useQuery: () => ({
+          isLoading: false,
+          data: {
+            id: 'gateway_1',
+            name: 'Gateway',
+            modelApiKey: 'sk-existing',
+            customModelBaseUrl: 'https://models.example.com/v1',
+            customModelName: 'old-model',
+            customModelStrategy: null,
+            customModelInputPrice: null,
+            customModelOutputPrice: null,
+          },
+        }),
+      },
+      update: {
+        useMutation: () => ({ mutateAsync: vi.fn() }),
+      },
+      testConnection: {
+        useMutation: (options: unknown) => {
+          mocks.testConnectionOptions.current = options;
+          return {
+            mutate: mocks.testConnectionMutate,
+            isPending: true,
+          };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('@/components/CommonWrapper', () => ({
+  CommonWrapper: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+vi.mock('@/components/ErrorTip', () => ({ ErrorTip: () => <div>Error</div> }));
+vi.mock('@/components/Loading', () => ({ Loading: () => <div>Loading</div> }));
+vi.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+vi.mock('@/components/aiGateway/AIGatewayStrategyEditor.utils', () => ({
+  parseAIGatewayCustomModelStrategy: vi.fn(),
+  stringifyAIGatewayCustomModelStrategy: () => '',
+}));
+vi.mock('@/components/aiGateway/AIGatewayEditForm', () => ({
+  AIGatewayEditForm: (props: any) => (
+    <div>
+      <span data-testid="testing-state">
+        {String(props.isTestingConnection)}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          props.onTestConnection({
+            name: 'Gateway',
+            modelApiKey: 'sk-current',
+            customModelBaseUrl: '',
+            customModelName: 'current-model',
+            customModelStrategy: '',
+            customModelInputPrice: null,
+            customModelOutputPrice: null,
+          })
+        }
+      >
+        Trigger Test
+      </button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.testConnectionOptions.current = null;
+});
+
+describe('AI Gateway edit route connection test', () => {
+  test('sends normalized current values and configures feedback', async () => {
+    const { Route } = await import(
+      '../../routes/aiGateway/$gatewayId/edit'
+    );
+    const Component = (Route as any).component;
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger Test' }));
+
+    expect(mocks.testConnectionMutate).toHaveBeenCalledWith({
+      workspaceId: 'workspace_1',
+      gatewayId: 'gateway_1',
+      modelApiKey: 'sk-current',
+      customModelBaseUrl: null,
+      customModelName: 'current-model',
+    });
+    expect(screen.getByTestId('testing-state')).toHaveTextContent('true');
+
+    mocks.testConnectionOptions.current.onSuccess({
+      model: 'current-model',
+      durationMs: 42,
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Connection successful', {
+      description: 'Model: current-model · 42 ms',
+    });
+    expect(mocks.testConnectionOptions.current.onError).toBe(
+      mocks.defaultErrorHandler
+    );
+  });
+});

--- a/src/client/components/aiGateway/AIGatewayTRPCLogger.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayTRPCLogger.component.spec.tsx
@@ -1,0 +1,35 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('@/utils/env', () => ({ isDev: true }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('does not log the connection-test API key when the request fails', async () => {
+  const apiKey = 'sk-sensitive-logger';
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network failed');
+    })
+  );
+  const { trpcClient } = await import('@/api/trpc');
+
+  await expect(
+    trpcClient.aiGateway.testConnection.mutate({
+      workspaceId: 'tz4a98xxat96iws9zmbrgj3a',
+      gatewayId: 'gateway_1',
+      modelApiKey: apiKey,
+      customModelBaseUrl: null,
+      customModelName: null,
+    })
+  ).rejects.toThrow();
+
+  expect(JSON.stringify([logSpy.mock.calls, errorSpy.mock.calls])).not.toContain(
+    apiKey
+  );
+});

--- a/src/client/routes/aiGateway/$gatewayId/edit.tsx
+++ b/src/client/routes/aiGateway/$gatewayId/edit.tsx
@@ -16,6 +16,7 @@ import {
   parseAIGatewayCustomModelStrategy,
   stringifyAIGatewayCustomModelStrategy,
 } from '@/components/aiGateway/AIGatewayStrategyEditor.utils';
+import { toast } from 'sonner';
 
 export const Route = createFileRoute('/aiGateway/$gatewayId/edit')({
   beforeLoad: routeAuthBeforeLoad,
@@ -35,6 +36,15 @@ function AIGatewayEditComponent() {
   });
 
   const updateGatewayMutation = trpc.aiGateway.update.useMutation({
+    onError: defaultErrorHandler,
+  });
+
+  const testConnectionMutation = trpc.aiGateway.testConnection.useMutation({
+    onSuccess: ({ model, durationMs }) => {
+      toast.success(t('Connection successful'), {
+        description: `${t('Model')}: ${model} · ${durationMs} ms`,
+      });
+    },
     onError: defaultErrorHandler,
   });
 
@@ -60,6 +70,16 @@ function AIGatewayEditComponent() {
       params: {
         gatewayId: res.id || gatewayId,
       },
+    });
+  });
+
+  const handleTestConnection = useEvent((values: AIGatewayEditFormValues) => {
+    testConnectionMutation.mutate({
+      workspaceId,
+      gatewayId,
+      modelApiKey: values.modelApiKey?.trim() ?? '',
+      customModelBaseUrl: values.customModelBaseUrl?.trim() || null,
+      customModelName: values.customModelName?.trim() || null,
     });
   });
 
@@ -93,6 +113,8 @@ function AIGatewayEditComponent() {
               : undefined
           }
           onSubmit={handleSubmit}
+          onTestConnection={handleTestConnection}
+          isTestingConnection={testConnectionMutation.isPending}
         />
       </ScrollArea>
     </CommonWrapper>

--- a/src/server/model/aiGateway/connectivity.spec.ts
+++ b/src/server/model/aiGateway/connectivity.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  AIGatewayConnectivityClient,
+  testAIGatewayCustomConnection,
+} from './connectivity.js';
+
+function createFakeClient(modelIds: string[] = []) {
+  const list = vi.fn(async () => ({
+    data: modelIds.map((id) => ({ id })),
+  }));
+  const create = vi.fn(async () => ({ id: 'completion_1' }));
+  const client: AIGatewayConnectivityClient = {
+    models: { list },
+    chat: { completions: { create } },
+  };
+
+  return { client, list, create };
+}
+
+describe('testAIGatewayCustomConnection', () => {
+  test('uses the configured model without requesting the model list', async () => {
+    const { client, list, create } = createFakeClient();
+    const createClient = vi.fn(() => client);
+    const now = vi.fn().mockReturnValueOnce(1_000).mockReturnValueOnce(1_035);
+
+    const result = await testAIGatewayCustomConnection(
+      {
+        modelApiKey: 'sk-current',
+        customModelBaseUrl: 'https://models.example.com/v1',
+        customModelName: '  configured-model  ',
+      },
+      { createClient, now }
+    );
+
+    expect(createClient).toHaveBeenCalledWith({
+      apiKey: 'sk-current',
+      baseURL: 'https://models.example.com/v1',
+      maxRetries: 0,
+      timeout: 15_000,
+    });
+    expect(list).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith({
+      model: 'configured-model',
+      messages: [{ role: 'user', content: 'Reply with OK.' }],
+      max_tokens: 1,
+      stream: false,
+    });
+    expect(result).toEqual({ model: 'configured-model', durationMs: 35 });
+  });
+
+  test('uses the first listed model when the configured model is empty', async () => {
+    const { client, list, create } = createFakeClient([
+      'first-model',
+      'second-model',
+    ]);
+
+    const result = await testAIGatewayCustomConnection(
+      {
+        modelApiKey: 'sk-current',
+        customModelBaseUrl: null,
+        customModelName: '   ',
+      },
+      {
+        createClient: () => client,
+        now: vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(28),
+      }
+    );
+
+    expect(list).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'first-model' })
+    );
+    expect(result).toEqual({ model: 'first-model', durationMs: 18 });
+  });
+
+  test('fails explicitly when the upstream model list is empty', async () => {
+    const { client, create } = createFakeClient();
+
+    await expect(
+      testAIGatewayCustomConnection(
+        {
+          modelApiKey: 'sk-current',
+          customModelBaseUrl: null,
+          customModelName: null,
+        },
+        { createClient: () => client }
+      )
+    ).rejects.toThrow('No models available from upstream');
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test('redacts the API key from upstream errors', async () => {
+    const { client, create } = createFakeClient();
+    create.mockRejectedValueOnce(
+      new Error('Authentication rejected credential sk-sensitive')
+    );
+
+    await expect(
+      testAIGatewayCustomConnection(
+        {
+          modelApiKey: 'sk-sensitive',
+          customModelBaseUrl: null,
+          customModelName: 'configured-model',
+        },
+        { createClient: () => client }
+      )
+    ).rejects.toThrow('Authentication rejected credential [REDACTED]');
+  });
+});

--- a/src/server/model/aiGateway/connectivity.spec.ts
+++ b/src/server/model/aiGateway/connectivity.spec.ts
@@ -127,4 +127,25 @@ describe('testAIGatewayCustomConnection', () => {
       )
     ).rejects.toThrow('Authentication rejected credential [REDACTED]');
   });
+
+  test('redacts the API key from the selected model after using the raw model upstream', async () => {
+    const { client, create } = createFakeClient();
+    const apiKey = 'sk-sensitive';
+    const rawModel = `provider/${apiKey}/model`;
+
+    const result = await testAIGatewayCustomConnection(
+      {
+        modelApiKey: apiKey,
+        customModelBaseUrl: null,
+        customModelName: rawModel,
+      },
+      { createClient: () => client }
+    );
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ model: rawModel })
+    );
+    expect(result.model).toBe('provider/[REDACTED]/model');
+    expect(JSON.stringify(result)).not.toContain(apiKey);
+  });
 });

--- a/src/server/model/aiGateway/connectivity.spec.ts
+++ b/src/server/model/aiGateway/connectivity.spec.ts
@@ -18,6 +18,26 @@ function createFakeClient(modelIds: string[] = []) {
 }
 
 describe('testAIGatewayCustomConnection', () => {
+  test('rejects a blank API key before creating the client', async () => {
+    const { client, list, create } = createFakeClient();
+    const createClient = vi.fn(() => client);
+
+    await expect(
+      testAIGatewayCustomConnection(
+        {
+          modelApiKey: '   ',
+          customModelBaseUrl: null,
+          customModelName: 'configured-model',
+        },
+        { createClient }
+      )
+    ).rejects.toThrow('API key is required');
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
   test('uses the configured model without requesting the model list', async () => {
     const { client, list, create } = createFakeClient();
     const createClient = vi.fn(() => client);

--- a/src/server/model/aiGateway/connectivity.spec.ts
+++ b/src/server/model/aiGateway/connectivity.spec.ts
@@ -110,6 +110,52 @@ describe('testAIGatewayCustomConnection', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  test.each([
+    { id: '   ' },
+    { id: 123 },
+    { id: { value: 'model' } },
+    {},
+    null,
+  ])('rejects an invalid first model id: $id', async (firstModel) => {
+    const { client, create } = createFakeClient();
+    client.models.list = vi.fn(async () => ({
+      data: [firstModel],
+    })) as AIGatewayConnectivityClient['models']['list'];
+
+    await expect(
+      testAIGatewayCustomConnection(
+        {
+          modelApiKey: 'sk-current',
+          customModelBaseUrl: null,
+          customModelName: null,
+        },
+        { createClient: () => client }
+      )
+    ).rejects.toThrow('No valid models available from upstream');
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test('rejects a model response whose data field is not an array', async () => {
+    const { client, create } = createFakeClient();
+    client.models.list = vi.fn(async () => ({
+      data: null,
+    })) as unknown as AIGatewayConnectivityClient['models']['list'];
+
+    await expect(
+      testAIGatewayCustomConnection(
+        {
+          modelApiKey: 'sk-current',
+          customModelBaseUrl: null,
+          customModelName: null,
+        },
+        { createClient: () => client }
+      )
+    ).rejects.toThrow('No valid models available from upstream');
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
   test('redacts the API key from upstream errors', async () => {
     const { client, create } = createFakeClient();
     create.mockRejectedValueOnce(

--- a/src/server/model/aiGateway/connectivity.ts
+++ b/src/server/model/aiGateway/connectivity.ts
@@ -56,6 +56,10 @@ export async function testAIGatewayCustomConnection(
   dependencies: AIGatewayConnectivityDependencies = {}
 ): Promise<TestAIGatewayCustomConnectionResult> {
   const modelApiKey = input.modelApiKey.trim();
+  if (!modelApiKey) {
+    throw new Error('API key is required');
+  }
+
   const createClient =
     dependencies.createClient ??
     ((options: AIGatewayConnectivityClientOptions) => new OpenAI(options));

--- a/src/server/model/aiGateway/connectivity.ts
+++ b/src/server/model/aiGateway/connectivity.ts
@@ -1,0 +1,97 @@
+import OpenAI from 'openai';
+
+export interface AIGatewayConnectivityClientOptions {
+  apiKey: string;
+  baseURL?: string;
+  maxRetries: 0;
+  timeout: 15_000;
+}
+
+export interface AIGatewayConnectivityClient {
+  models: {
+    list(): Promise<{ data: Array<{ id: string }> }>;
+  };
+  chat: {
+    completions: {
+      create(input: {
+        model: string;
+        messages: Array<{ role: 'user'; content: string }>;
+        max_tokens: 1;
+        stream: false;
+      }): Promise<unknown>;
+    };
+  };
+}
+
+export interface TestAIGatewayCustomConnectionInput {
+  modelApiKey: string;
+  customModelBaseUrl: string | null;
+  customModelName: string | null;
+}
+
+export interface TestAIGatewayCustomConnectionResult {
+  model: string;
+  durationMs: number;
+}
+
+interface AIGatewayConnectivityDependencies {
+  createClient?: (
+    options: AIGatewayConnectivityClientOptions
+  ) => AIGatewayConnectivityClient;
+  now?: () => number;
+}
+
+function normalizeOptionalString(value: string | null): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function getSafeErrorMessage(error: unknown, secret: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return secret ? message.split(secret).join('[REDACTED]') : message;
+}
+
+export async function testAIGatewayCustomConnection(
+  input: TestAIGatewayCustomConnectionInput,
+  dependencies: AIGatewayConnectivityDependencies = {}
+): Promise<TestAIGatewayCustomConnectionResult> {
+  const modelApiKey = input.modelApiKey.trim();
+  const createClient =
+    dependencies.createClient ??
+    ((options: AIGatewayConnectivityClientOptions) => new OpenAI(options));
+  const now = dependencies.now ?? Date.now;
+  const startedAt = now();
+
+  try {
+    const client = createClient({
+      apiKey: modelApiKey,
+      baseURL: normalizeOptionalString(input.customModelBaseUrl),
+      maxRetries: 0,
+      timeout: 15_000,
+    });
+
+    let model = normalizeOptionalString(input.customModelName);
+    if (!model) {
+      const models = await client.models.list();
+      model = models.data[0]?.id;
+    }
+
+    if (!model) {
+      throw new Error('No models available from upstream');
+    }
+
+    await client.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: 'Reply with OK.' }],
+      max_tokens: 1,
+      stream: false,
+    });
+
+    return {
+      model,
+      durationMs: Math.max(0, now() - startedAt),
+    };
+  } catch (error) {
+    throw new Error(getSafeErrorMessage(error, modelApiKey));
+  }
+}

--- a/src/server/model/aiGateway/connectivity.ts
+++ b/src/server/model/aiGateway/connectivity.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import { redactSecret } from './redactSecret.js';
 
 export interface AIGatewayConnectivityClientOptions {
   apiKey: string;
@@ -48,7 +49,7 @@ function normalizeOptionalString(value: string | null): string | undefined {
 
 function getSafeErrorMessage(error: unknown, secret: string): string {
   const message = error instanceof Error ? error.message : String(error);
-  return secret ? message.split(secret).join('[REDACTED]') : message;
+  return redactSecret(message, secret);
 }
 
 export async function testAIGatewayCustomConnection(
@@ -92,7 +93,7 @@ export async function testAIGatewayCustomConnection(
     });
 
     return {
-      model,
+      model: redactSecret(model, modelApiKey),
       durationMs: Math.max(0, now() - startedAt),
     };
   } catch (error) {

--- a/src/server/model/aiGateway/connectivity.ts
+++ b/src/server/model/aiGateway/connectivity.ts
@@ -78,7 +78,20 @@ export async function testAIGatewayCustomConnection(
     let model = normalizeOptionalString(input.customModelName);
     if (!model) {
       const models = await client.models.list();
-      model = models.data[0]?.id;
+      if (!Array.isArray(models.data)) {
+        throw new Error('No valid models available from upstream');
+      }
+      if (models.data.length === 0) {
+        throw new Error('No models available from upstream');
+      }
+      const firstModelId = models.data[0]?.id;
+      if (
+        typeof firstModelId !== 'string' ||
+        !firstModelId.trim()
+      ) {
+        throw new Error('No valid models available from upstream');
+      }
+      model = firstModelId.trim();
     }
 
     if (!model) {

--- a/src/server/model/aiGateway/redactSecret.ts
+++ b/src/server/model/aiGateway/redactSecret.ts
@@ -1,0 +1,3 @@
+export function redactSecret(value: string, secret: string): string {
+  return secret ? value.split(secret).join('[REDACTED]') : value;
+}

--- a/src/server/trpc/routers/aiGateway.spec.ts
+++ b/src/server/trpc/routers/aiGateway.spec.ts
@@ -127,6 +127,31 @@ describe('aiGatewayRouter.testConnection', () => {
     expect(JSON.stringify(result)).not.toContain('sk-current');
   });
 
+  test('redacts the submitted API key from a successful service result', async () => {
+    const workspaceId = createId();
+    const apiKey = 'sk-sensitive';
+    mocks.findGateway.mockResolvedValue({ id: 'gateway_1' });
+    mocks.testConnection.mockResolvedValue({
+      model: `provider/${apiKey}/model`,
+      durationMs: 42,
+    });
+    const caller = await createCaller();
+
+    const result = await caller.testConnection({
+      workspaceId,
+      gatewayId: 'gateway_1',
+      modelApiKey: apiKey,
+      customModelBaseUrl: null,
+      customModelName: null,
+    });
+
+    expect(result).toEqual({
+      model: 'provider/[REDACTED]/model',
+      durationMs: 42,
+    });
+    expect(JSON.stringify(result)).not.toContain(apiKey);
+  });
+
   test('maps upstream failures to a BAD_GATEWAY error', async () => {
     const workspaceId = createId();
     mocks.findGateway.mockResolvedValue({ id: 'gateway_1' });

--- a/src/server/trpc/routers/aiGateway.spec.ts
+++ b/src/server/trpc/routers/aiGateway.spec.ts
@@ -1,0 +1,149 @@
+import { createId } from '@paralleldrive/cuid2';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const endRequest = vi.fn();
+
+  return {
+    endRequest,
+    jwtVerify: vi.fn(() => ({
+      id: 'user-id',
+      username: 'user',
+      role: 'user',
+    })),
+    getWorkspaceUser: vi.fn(async () => ({ role: 'owner' })),
+    promStartTimer: vi.fn(() => endRequest),
+    findGateway: vi.fn(),
+    testConnection: vi.fn(),
+  };
+});
+
+vi.mock('../../middleware/auth.js', () => ({
+  jwtVerify: mocks.jwtVerify,
+}));
+
+vi.mock('../../model/auth.js', () => ({ authConfig: {} }));
+
+vi.mock('../../model/user.js', () => ({
+  verifyUserApiKey: vi.fn(),
+}));
+
+vi.mock('../../model/workspace.js', () => ({
+  getWorkspaceUser: mocks.getWorkspaceUser,
+}));
+
+vi.mock('../../utils/prometheus/client.js', () => ({
+  promTrpcRequest: { startTimer: mocks.promStartTimer },
+}));
+
+vi.mock('../../model/_client.js', () => ({
+  prisma: {
+    aIGateway: { findFirst: mocks.findGateway },
+  },
+}));
+
+vi.mock('../../model/aiGateway.js', () => ({
+  clearGatewayInfoCache: vi.fn(),
+}));
+
+vi.mock('../../model/aiGateway/quotaAlert.js', () => ({
+  clearQuotaAlertCacheForGateway: vi.fn(),
+}));
+
+vi.mock('../../model/aiGateway/connectivity.js', () => ({
+  testAIGatewayCustomConnection: mocks.testConnection,
+}));
+
+async function createCaller() {
+  const { aiGatewayRouter } = await import('./aiGateway.js');
+
+  return aiGatewayRouter.createCaller({
+    token: 'jwt-token',
+    timezone: 'utc',
+    language: 'en',
+    req: {} as any,
+    origin: '',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getWorkspaceUser.mockResolvedValue({ role: 'owner' });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('aiGatewayRouter.testConnection', () => {
+  test('rejects a gateway outside the current workspace', async () => {
+    const workspaceId = createId();
+    mocks.findGateway.mockResolvedValue(null);
+    const caller = await createCaller();
+
+    await expect(
+      caller.testConnection({
+        workspaceId,
+        gatewayId: 'gateway_1',
+        modelApiKey: 'sk-current',
+        customModelBaseUrl: 'https://models.example.com/v1',
+        customModelName: null,
+      })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'AI Gateway not found',
+    });
+
+    expect(mocks.findGateway).toHaveBeenCalledWith({
+      where: { id: 'gateway_1', workspaceId },
+      select: { id: true },
+    });
+    expect(mocks.testConnection).not.toHaveBeenCalled();
+  });
+
+  test('returns only the selected model and duration', async () => {
+    const workspaceId = createId();
+    mocks.findGateway.mockResolvedValue({ id: 'gateway_1' });
+    mocks.testConnection.mockResolvedValue({
+      model: 'selected-model',
+      durationMs: 42,
+    });
+    const caller = await createCaller();
+
+    const result = await caller.testConnection({
+      workspaceId,
+      gatewayId: 'gateway_1',
+      modelApiKey: 'sk-current',
+      customModelBaseUrl: 'https://models.example.com/v1',
+      customModelName: 'selected-model',
+    });
+
+    expect(mocks.testConnection).toHaveBeenCalledWith({
+      modelApiKey: 'sk-current',
+      customModelBaseUrl: 'https://models.example.com/v1',
+      customModelName: 'selected-model',
+    });
+    expect(result).toEqual({ model: 'selected-model', durationMs: 42 });
+    expect(JSON.stringify(result)).not.toContain('sk-current');
+  });
+
+  test('maps upstream failures to a BAD_GATEWAY error', async () => {
+    const workspaceId = createId();
+    mocks.findGateway.mockResolvedValue({ id: 'gateway_1' });
+    mocks.testConnection.mockRejectedValue(new Error('Authentication failed'));
+    const caller = await createCaller();
+
+    await expect(
+      caller.testConnection({
+        workspaceId,
+        gatewayId: 'gateway_1',
+        modelApiKey: 'sk-current',
+        customModelBaseUrl: null,
+        customModelName: 'selected-model',
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_GATEWAY',
+      message: 'Authentication failed',
+    });
+  });
+});

--- a/src/server/trpc/routers/aiGateway.ts
+++ b/src/server/trpc/routers/aiGateway.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 import {
   OpenApiMetaInfo,
   router,
@@ -14,6 +15,7 @@ import { fetchDataByCursor } from '../../utils/prisma.js';
 import { buildCursorResponseSchema } from '../../utils/schema.js';
 import { clearGatewayInfoCache } from '../../model/aiGateway.js';
 import { clearQuotaAlertCacheForGateway } from '../../model/aiGateway/quotaAlert.js';
+import { testAIGatewayCustomConnection } from '../../model/aiGateway/connectivity.js';
 import { logger } from '../../utils/logger.js';
 
 const modelPricingData = await import(
@@ -248,6 +250,59 @@ export const aiGatewayRouter = router({
           ? Number(aiGateway.customModelOutputPrice)
           : null,
       };
+    }),
+
+  testConnection: workspaceAdminProcedure
+    .input(
+      z.object({
+        gatewayId: z.string(),
+        modelApiKey: z.string().trim().min(1, 'Model API Key is required'),
+        customModelBaseUrl: z.string().trim().url().nullable(),
+        customModelName: z.string().nullable(),
+      })
+    )
+    .output(
+      z.object({
+        model: z.string(),
+        durationMs: z.number().nonnegative(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const {
+        workspaceId,
+        gatewayId,
+        modelApiKey,
+        customModelBaseUrl,
+        customModelName,
+      } = input;
+      const gateway = await prisma.aIGateway.findFirst({
+        where: { id: gatewayId, workspaceId },
+        select: { id: true },
+      });
+
+      if (!gateway) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'AI Gateway not found',
+        });
+      }
+
+      try {
+        return await testAIGatewayCustomConnection({
+          modelApiKey,
+          customModelBaseUrl,
+          customModelName,
+        });
+      } catch (error) {
+        throw new TRPCError({
+          code: 'BAD_GATEWAY',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'AI Gateway connection test failed',
+          cause: error,
+        });
+      }
     }),
 
   delete: workspaceAdminProcedure

--- a/src/server/trpc/routers/aiGateway.ts
+++ b/src/server/trpc/routers/aiGateway.ts
@@ -16,6 +16,7 @@ import { buildCursorResponseSchema } from '../../utils/schema.js';
 import { clearGatewayInfoCache } from '../../model/aiGateway.js';
 import { clearQuotaAlertCacheForGateway } from '../../model/aiGateway/quotaAlert.js';
 import { testAIGatewayCustomConnection } from '../../model/aiGateway/connectivity.js';
+import { redactSecret } from '../../model/aiGateway/redactSecret.js';
 import { logger } from '../../utils/logger.js';
 
 const modelPricingData = await import(
@@ -288,11 +289,16 @@ export const aiGatewayRouter = router({
       }
 
       try {
-        return await testAIGatewayCustomConnection({
+        const result = await testAIGatewayCustomConnection({
           modelApiKey,
           customModelBaseUrl,
           customModelName,
         });
+
+        return {
+          ...result,
+          model: redactSecret(result.model, modelApiKey),
+        };
       } catch (error) {
         throw new TRPCError({
           code: 'BAD_GATEWAY',


### PR DESCRIPTION
## Background
Administrators need a way to validate unsaved custom AI Gateway settings before updating a gateway, while avoiding accidental persistence, analytics noise, or secret exposure.

## Changes
- Add a custom AI Gateway connectivity service that tests OpenAI-compatible upstreams with a minimal non-streaming chat completion.
- Expose an `aiGateway.testConnection` workspace-admin mutation that verifies gateway ownership and returns model and duration.
- Add a `Test Connection` action to the AI Gateway edit form using current unsaved form values.
- Reject blank API keys and harden model-list validation for empty or invalid upstream responses.
- Redact submitted API keys from connectivity results, errors, and client tRPC logging.

## Testing
Added Vitest coverage for the connectivity service, tRPC mutation behavior, edit form action, edit route mutation wiring, and tRPC logger secret redaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Test Connection** action to the AI Gateway edit form.
  * Tests current unsaved gateway settings without saving changes or altering configuration.
  * Displays connection success details, including the detected model and response time.
  * Supports custom base URLs and model names, with fallback model detection when needed.

* **Security**
  * API keys are excluded from logs, responses, and displayed error messages.
  * Connection testing is restricted to authorized workspace administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->