### PR TITLE
feat(ai-gateway): add duplicate gateway action

### DIFF
--- a/docs/superpowers/plans/2026-07-17-ai-gateway-duplicate.md
+++ b/docs/superpowers/plans/2026-07-17-ai-gateway-duplicate.md
@@ -1,0 +1,203 @@
+# AI Gateway Duplicate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an administrator-only duplicate action that copies an AI Gateway's configuration and API key entirely on the server.
+
+**Architecture:** A dedicated `aiGateway.duplicate` mutation accepts only the source ID and new name, copies an explicitly selected set of scalar fields inside the current workspace, and returns only the new ID and name. The existing detail page owns a small dialog that calls the mutation, refreshes the list, and navigates to the duplicate.
+
+**Tech Stack:** TypeScript, tRPC, Zod, Prisma, React, TanStack Router, Vitest, Testing Library
+
+## Global Constraints
+
+- The duplicate request and response must never contain `modelApiKey`.
+- The server must copy `modelApiKey` directly between Prisma read and create operations.
+- Copy only Gateway scalar configuration; do not copy logs, quota alerts, or AI Router relationships.
+- Do not modify JSON files under `src/client/public/locales`.
+- All mutations require workspace administrator permission.
+
+---
+
+### Task 1: Secure server-side duplicate mutation
+
+**Files:**
+- Modify: `src/server/trpc/routers/aiGateway.spec.ts`
+- Modify: `src/server/trpc/routers/aiGateway.ts`
+
+**Interfaces:**
+- Consumes: `workspaceAdminProcedure`, `prisma.aIGateway.findFirst`, and `prisma.aIGateway.create`
+- Produces: `aiGateway.duplicate({ workspaceId, gatewayId, name }): Promise<{ id: string; name: string }>`
+
+- [ ] **Step 1: Extend the router test Prisma mock and write failing duplicate tests**
+
+Add `createGateway` to the hoisted mocks and cover workspace isolation, exact scalar copying, safe response shape, and name validation. The core success assertion must be:
+
+```ts
+expect(mocks.createGateway).toHaveBeenCalledWith({
+  data: {
+    workspaceId,
+    name: 'Gateway Copy',
+    modelApiKey: apiKey,
+    customModelBaseUrl: 'https://models.example.com/v1',
+    customModelName: 'model-a',
+    customModelStrategy: { price: { input: 1 } },
+    customModelInputPrice: 2,
+    customModelOutputPrice: 3,
+  },
+  select: { id: true, name: true },
+});
+expect(result).toEqual({ id: 'gateway_copy', name: 'Gateway Copy' });
+expect(JSON.stringify(result)).not.toContain(apiKey);
+```
+
+- [ ] **Step 2: Run the focused server tests and verify RED**
+
+Run: `pnpm --dir src/server exec vitest run trpc/routers/aiGateway.spec.ts`
+
+Expected: duplicate tests fail because `caller.duplicate` and the Prisma create mock wiring do not exist.
+
+- [ ] **Step 3: Implement the minimal duplicate mutation**
+
+Add dedicated schemas and a router member equivalent to:
+
+```ts
+const aiGatewayDuplicateOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+duplicate: workspaceAdminProcedure
+  .input(z.object({
+    gatewayId: z.string(),
+    name: z.string().trim().min(1).max(100),
+  }))
+  .output(aiGatewayDuplicateOutputSchema)
+  .mutation(async ({ input }) => {
+    const source = await prisma.aIGateway.findFirst({
+      where: { id: input.gatewayId, workspaceId: input.workspaceId },
+      select: {
+        modelApiKey: true,
+        customModelBaseUrl: true,
+        customModelName: true,
+        customModelStrategy: true,
+        customModelInputPrice: true,
+        customModelOutputPrice: true,
+      },
+    });
+    if (!source) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'AI Gateway not found' });
+    }
+    return prisma.aIGateway.create({
+      data: { workspaceId: input.workspaceId, name: input.name, ...source },
+      select: { id: true, name: true },
+    });
+  }),
+```
+
+- [ ] **Step 4: Run the focused server tests and verify GREEN**
+
+Run: `pnpm --dir src/server exec vitest run trpc/routers/aiGateway.spec.ts`
+
+Expected: all tests in the file pass and no output contains the test token.
+
+- [ ] **Step 5: Commit the server behavior**
+
+```bash
+git add src/server/trpc/routers/aiGateway.ts src/server/trpc/routers/aiGateway.spec.ts
+git diff --cached --check
+git commit -m "feat(ai-gateway): add secure duplicate mutation"
+```
+
+### Task 2: Administrator duplicate dialog and navigation
+
+**Files:**
+- Create: `src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx`
+- Create: `src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx`
+- Modify: `src/client/routes/aiGateway/$gatewayId/index.tsx`
+
+**Interfaces:**
+- Consumes: `trpc.aiGateway.duplicate`, current `workspaceId`, `gatewayId`, and Gateway name
+- Produces: `AIGatewayDuplicateDialog({ gatewayId, gatewayName })` and an administrator-only icon trigger
+
+- [ ] **Step 1: Write failing component tests**
+
+Test that opening shows `${gatewayName} - Copy`, submitting trims the name and sends exactly:
+
+```ts
+{
+  workspaceId: 'workspace_1',
+  gatewayId: 'gateway_1',
+  name: 'Gateway Copy',
+}
+```
+
+Also test that success refetches `aiGateway.all`, navigates to `/aiGateway/$gatewayId` using the returned ID, empty input cannot submit, pending state disables controls, and rejection preserves the dialog value.
+
+- [ ] **Step 2: Run the focused client test and verify RED**
+
+Run: `pnpm --dir src/client exec vitest run --config vitest.component.config.ts components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx`
+
+Expected: test collection fails because `AIGatewayDuplicateDialog.tsx` does not exist.
+
+- [ ] **Step 3: Implement the dialog component**
+
+Use the existing `Dialog`, `Input`, `Label`, and `Button` components. Keep state local, call `defaultErrorHandler` through mutation options, and prevent `onOpenChange` from closing while pending. The mutation payload must be constructed only from workspace ID, source ID, and trimmed name.
+
+- [ ] **Step 4: Wire the action into the detail header**
+
+Render `<AIGatewayDuplicateDialog gatewayId={gatewayId} gatewayName={gateway.name} />` inside the existing `hasAdminPermission` fragment before the edit action. The dialog owns a `LuCopy` icon trigger with an accessible `title`.
+
+- [ ] **Step 5: Run the focused client test and verify GREEN**
+
+Run: `pnpm --dir src/client exec vitest run --config vitest.component.config.ts components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx`
+
+Expected: all duplicate dialog tests pass.
+
+- [ ] **Step 6: Commit the client behavior**
+
+```bash
+git add src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx 'src/client/routes/aiGateway/$gatewayId/index.tsx'
+git diff --cached --check
+git commit -m "feat(ai-gateway): add duplicate action"
+```
+
+### Task 3: Full verification
+
+**Files:**
+- Verify only; no planned modifications
+
+**Interfaces:**
+- Consumes: the server mutation and client duplicate dialog from Tasks 1 and 2
+- Produces: fresh evidence that focused behavior, types, and production build pass
+
+- [ ] **Step 1: Run both focused suites together**
+
+```bash
+pnpm --dir src/server exec vitest run trpc/routers/aiGateway.spec.ts
+pnpm --dir src/client exec vitest run --config vitest.component.config.ts components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+```
+
+Expected: both commands exit 0 with zero failed tests.
+
+- [ ] **Step 2: Run type checking**
+
+Run: `pnpm check:type`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `pnpm build`
+
+Expected: exit 0.
+
+- [ ] **Step 4: Audit final scope and secret handling**
+
+```bash
+git status --short
+git diff master...HEAD --check
+git diff master...HEAD --name-only
+rg -n "modelApiKey" src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx 'src/client/routes/aiGateway/$gatewayId/index.tsx'
+```
+
+Expected: only intentional files and commits are present; the final `rg` command has no matches.

--- a/docs/superpowers/specs/2026-07-17-ai-gateway-duplicate-design.md
+++ b/docs/superpowers/specs/2026-07-17-ai-gateway-duplicate-design.md
@@ -1,0 +1,104 @@
+# AI Gateway Duplicate Design
+
+## Goal
+
+Allow workspace administrators to duplicate an AI Gateway while preserving its upstream model API key without sending that secret through the browser or returning it from the duplicate operation.
+
+## Scope
+
+The duplicate contains only the source Gateway's own model configuration:
+
+- `modelApiKey`
+- `customModelBaseUrl`
+- `customModelName`
+- `customModelStrategy`
+- `customModelInputPrice`
+- `customModelOutputPrice`
+
+The duplicate receives a new ID, creation timestamp, update timestamp, and user-selected name. Historical logs, quota alerts, and AI Router node relationships are not copied.
+
+## User Experience
+
+The AI Gateway detail header shows a duplicate icon button beside the existing edit and delete actions. Like the other mutating controls, it is visible only to workspace administrators.
+
+Selecting the button opens a `Duplicate AI Gateway` dialog. The name field defaults to `<source name> - Copy` and remains editable. The dialog provides Cancel and Duplicate actions. The Duplicate action is disabled for an empty or whitespace-only name; while the request is pending, both closing the dialog and resubmitting are prevented.
+
+On success, the client refreshes the AI Gateway list, closes the dialog, and navigates to the new Gateway's detail page. On failure, the existing error handler displays the error while the dialog and entered name remain available for retry.
+
+New UI strings use the existing `t(...)` translation convention. Files under `src/client/public/locales` are not modified.
+
+## Server API
+
+Add `aiGateway.duplicate` as a `workspaceAdminProcedure` mutation.
+
+Input:
+
+```ts
+{
+  workspaceId: string;
+  gatewayId: string;
+  name: string; // trimmed, 1..100 characters
+}
+```
+
+The mutation queries the source with both `workspaceId` and `gatewayId`. A missing source returns a `NOT_FOUND` tRPC error with the message `AI Gateway not found`.
+
+The source query selects only the six configuration fields required for the copy. The subsequent create writes those fields, the current workspace ID, and the validated name. Relations are omitted so Prisma creates no dependent records.
+
+Output:
+
+```ts
+{
+  id: string;
+  name: string;
+}
+```
+
+A dedicated output schema is used instead of `AIGatewayModelSchema`, ensuring the duplicate response cannot contain `modelApiKey` or other configuration data.
+
+## Secret-Handling Boundary
+
+The browser never receives the source token as part of this workflow:
+
+1. The UI sends only `workspaceId`, `gatewayId`, and `name`.
+2. The server reads `modelApiKey` directly from the database and passes it directly to Prisma create.
+3. Neither successful output nor expected error messages include source configuration.
+4. The mutation input contains no secret, so it does not require an entry in the client tRPC logger's sensitive-operation exclusion set.
+
+This design protects the duplicate path even though the existing edit query currently supplies configuration to the edit screen. Changing the broader edit/read API contract is outside this feature's scope because it would require a separate secret replacement design.
+
+## Error Handling
+
+- Invalid names fail input validation before database access.
+- Cross-workspace or nonexistent source IDs return `NOT_FOUND` without revealing whether that ID exists elsewhere.
+- Database failures propagate through the standard tRPC error handling. The server does not interpolate source data into error messages.
+- The client keeps the dialog open after mutation failure and relies on `defaultErrorHandler` for feedback.
+
+## Testing
+
+Server router tests will verify:
+
+- A source outside the current workspace is rejected and no create occurs.
+- All six Gateway configuration fields, including `modelApiKey`, are copied server-to-server.
+- The response is exactly `{ id, name }` and its serialized form does not contain the token.
+- Logs, quota alerts, and AI Router relationships are absent from the create payload.
+- Whitespace-only and overlength names fail validation.
+
+Client component tests will verify:
+
+- Only administrators see the duplicate action.
+- Opening the dialog uses the expected default name.
+- Submission sends only `workspaceId`, `gatewayId`, and the trimmed name.
+- Successful duplication refreshes the list and navigates to the new Gateway.
+- Empty names and pending requests cannot submit twice.
+- Failure leaves the dialog and name intact.
+
+Final verification runs the focused server and client Vitest suites, `pnpm check:type`, and `pnpm build`.
+
+## Out of Scope
+
+- Copying logs, analytics, quota alerts, or AI Router membership
+- Cross-workspace duplication
+- Bulk duplication
+- Changing the existing edit/read secret contract
+- Modifying generated translation JSON files

--- a/src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  hasAdminPermission: true,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute:
+    () =>
+    (options: Record<string, unknown>) => ({
+      ...options,
+      useParams: () => ({ gatewayId: 'gateway_1' }),
+    }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@i18next-toolkit/react', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/utils/route', () => ({ routeAuthBeforeLoad: vi.fn() }));
+vi.mock('@/store/user', () => ({
+  useCurrentWorkspaceId: () => 'workspace_1',
+  useHasAdminPermission: () => mocks.hasAdminPermission,
+}));
+
+vi.mock('@/api/trpc', () => ({
+  defaultErrorHandler: vi.fn(),
+  trpc: {
+    useUtils: () => ({ aiGateway: { all: { refetch: vi.fn() } } }),
+    aiGateway: {
+      info: {
+        useQuery: () => ({
+          isLoading: false,
+          data: { id: 'gateway_1', name: 'Primary Gateway' },
+        }),
+      },
+      delete: {
+        useMutation: () => ({ mutateAsync: vi.fn() }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/components/CommonWrapper', () => ({
+  CommonWrapper: ({ header }: { header: React.ReactNode }) => <div>{header}</div>,
+}));
+vi.mock('@/components/CommonHeader', () => ({
+  CommonHeader: ({ actions }: { actions: React.ReactNode }) => (
+    <div>{actions}</div>
+  ),
+}));
+vi.mock('@/components/aiGateway/AIGatewayCodeExampleBtn', () => ({
+  AIGatewayCodeExampleBtn: () => <div>Code example</div>,
+}));
+vi.mock('@/components/aiGateway/AIGatewayDuplicateDialog', () => ({
+  AIGatewayDuplicateDialog: () => <div aria-label="Duplicate action" />,
+}));
+vi.mock('@/components/AlertConfirm', () => ({
+  AlertConfirm: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    Icon: _Icon,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    Icon?: React.ComponentType;
+  }) => <button {...props} />,
+}));
+
+beforeEach(() => {
+  mocks.hasAdminPermission = true;
+});
+
+describe('AI Gateway detail route duplicate action', () => {
+  test('shows the duplicate action to workspace administrators', async () => {
+    const { Route } = await import('../../routes/aiGateway/$gatewayId/index');
+    const Component = (Route as any).component;
+
+    render(<Component />);
+
+    expect(screen.getByLabelText('Duplicate action')).toBeInTheDocument();
+  });
+
+  test('hides the duplicate action from non-administrators', async () => {
+    mocks.hasAdminPermission = false;
+    const { Route } = await import('../../routes/aiGateway/$gatewayId/index');
+    const Component = (Route as any).component;
+
+    render(<Component />);
+
+    expect(screen.queryByLabelText('Duplicate action')).not.toBeInTheDocument();
+  });
+});

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AIGatewayDuplicateDialog } from './AIGatewayDuplicateDialog';
+
+const mocks = vi.hoisted(() => ({
+  duplicate: vi.fn(),
+  refetchGateways: vi.fn(),
+  navigate: vi.fn(),
+  defaultErrorHandler: vi.fn(),
+  mutationOptions: { current: null as any },
+  isPending: false,
+}));
+
+vi.mock('@i18next-toolkit/react', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('@/store/user', () => ({
+  useCurrentWorkspaceId: () => 'workspace_1',
+}));
+
+vi.mock('@/api/trpc', () => ({
+  defaultErrorHandler: mocks.defaultErrorHandler,
+  trpc: {
+    useUtils: () => ({
+      aiGateway: { all: { refetch: mocks.refetchGateways } },
+    }),
+    aiGateway: {
+      duplicate: {
+        useMutation: (options: unknown) => {
+          mocks.mutationOptions.current = options;
+          return {
+            mutateAsync: mocks.duplicate,
+            isPending: mocks.isPending,
+          };
+        },
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isPending = false;
+  mocks.mutationOptions.current = null;
+  mocks.duplicate.mockResolvedValue({
+    id: 'gateway_copy',
+    name: 'Gateway Copy',
+  });
+  mocks.refetchGateways.mockResolvedValue(undefined);
+});
+
+describe('AIGatewayDuplicateDialog', () => {
+  test('uses a default copy name and submits only safe fields', async () => {
+    render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    const nameInput = screen.getByLabelText('AI Gateway Name');
+    expect(nameInput).toHaveValue('Primary Gateway - Copy');
+
+    fireEvent.change(nameInput, { target: { value: '  Gateway Copy  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate gateway' }));
+
+    await waitFor(() => {
+      expect(mocks.duplicate).toHaveBeenCalledWith({
+        workspaceId: 'workspace_1',
+        gatewayId: 'gateway_1',
+        name: 'Gateway Copy',
+      });
+    });
+    expect(JSON.stringify(mocks.duplicate.mock.calls)).not.toContain(
+      'modelApiKey'
+    );
+    expect(mocks.mutationOptions.current.onError).toBe(
+      mocks.defaultErrorHandler
+    );
+  });
+
+  test('refreshes the list and navigates to the duplicate on success', async () => {
+    render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate gateway' }));
+
+    await waitFor(() => {
+      expect(mocks.refetchGateways).toHaveBeenCalledWith({
+        workspaceId: 'workspace_1',
+      });
+      expect(mocks.navigate).toHaveBeenCalledWith({
+        to: '/aiGateway/$gatewayId',
+        params: { gatewayId: 'gateway_copy' },
+      });
+    });
+    expect(
+      screen.queryByRole('heading', { name: 'Duplicate AI Gateway' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not submit an empty name', () => {
+    render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.change(screen.getByLabelText('AI Gateway Name'), {
+      target: { value: '   ' },
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Duplicate gateway' })
+    ).toBeDisabled();
+    expect(mocks.duplicate).not.toHaveBeenCalled();
+  });
+
+  test('prevents closing or resubmitting while pending', () => {
+    const { rerender } = render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+
+    mocks.isPending = true;
+    rerender(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Duplicate gateway' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(
+      screen.getByRole('heading', { name: 'Duplicate AI Gateway' })
+    ).toBeInTheDocument();
+  });
+
+  test('keeps the dialog and entered name when duplication fails', async () => {
+    mocks.duplicate.mockRejectedValue(new Error('database unavailable'));
+    render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName="Primary Gateway"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    const nameInput = screen.getByLabelText('AI Gateway Name');
+    fireEvent.change(nameInput, { target: { value: 'Retry Name' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate gateway' }));
+
+    await waitFor(() => expect(mocks.duplicate).toHaveBeenCalledOnce());
+    expect(
+      screen.getByRole('heading', { name: 'Duplicate AI Gateway' })
+    ).toBeInTheDocument();
+    expect(nameInput).toHaveValue('Retry Name');
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
@@ -131,6 +131,23 @@ describe('AIGatewayDuplicateDialog', () => {
     expect(mocks.duplicate).not.toHaveBeenCalled();
   });
 
+  test('keeps the default copy name within the server length limit', () => {
+    render(
+      <AIGatewayDuplicateDialog
+        gatewayId="gateway_1"
+        gatewayName={'a'.repeat(100)}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+
+    const defaultName = screen.getByLabelText('AI Gateway Name').getAttribute(
+      'value'
+    );
+    expect(defaultName).toHaveLength(100);
+    expect(defaultName).toMatch(/ - Copy$/);
+  });
+
   test('prevents closing or resubmitting while pending', () => {
     const { rerender } = render(
       <AIGatewayDuplicateDialog

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
@@ -23,6 +23,16 @@ interface AIGatewayDuplicateDialogProps {
   gatewayName: string;
 }
 
+const MAX_GATEWAY_NAME_LENGTH = 100;
+const COPY_NAME_SUFFIX = ' - Copy';
+
+function buildDuplicateName(gatewayName: string) {
+  return `${gatewayName.slice(
+    0,
+    MAX_GATEWAY_NAME_LENGTH - COPY_NAME_SUFFIX.length
+  )}${COPY_NAME_SUFFIX}`;
+}
+
 export function AIGatewayDuplicateDialog({
   gatewayId,
   gatewayName,
@@ -44,7 +54,7 @@ export function AIGatewayDuplicateDialog({
     }
 
     setOpen(nextOpen);
-    setName(nextOpen ? `${gatewayName} - Copy` : '');
+    setName(nextOpen ? buildDuplicateName(gatewayName) : '');
   });
 
   const handleDuplicate = useEvent(async () => {
@@ -112,7 +122,7 @@ export function AIGatewayDuplicateDialog({
               id="ai-gateway-duplicate-name"
               className="col-span-3"
               value={name}
-              maxLength={100}
+              maxLength={MAX_GATEWAY_NAME_LENGTH}
               onChange={(event) => setName(event.target.value)}
             />
           </div>

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useTranslation } from '@i18next-toolkit/react';
+import { LuCopy } from 'react-icons/lu';
+import { defaultErrorHandler, trpc } from '@/api/trpc';
+import { useEvent } from '@/hooks/useEvent';
+import { useCurrentWorkspaceId } from '@/store/user';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface AIGatewayDuplicateDialogProps {
+  gatewayId: string;
+  gatewayName: string;
+}
+
+export function AIGatewayDuplicateDialog({
+  gatewayId,
+  gatewayName,
+}: AIGatewayDuplicateDialogProps) {
+  const { t } = useTranslation();
+  const workspaceId = useCurrentWorkspaceId();
+  const navigate = useNavigate();
+  const trpcUtils = trpc.useUtils();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+
+  const duplicateMutation = trpc.aiGateway.duplicate.useMutation({
+    onError: defaultErrorHandler,
+  });
+
+  const handleOpenChange = useEvent((nextOpen: boolean) => {
+    if (duplicateMutation.isPending) {
+      return;
+    }
+
+    setOpen(nextOpen);
+    setName(nextOpen ? `${gatewayName} - Copy` : '');
+  });
+
+  const handleDuplicate = useEvent(async () => {
+    const duplicateName = name.trim();
+    if (!duplicateName || duplicateMutation.isPending) {
+      return;
+    }
+
+    try {
+      const duplicate = await duplicateMutation.mutateAsync({
+        workspaceId,
+        gatewayId,
+        name: duplicateName,
+      });
+
+      await trpcUtils.aiGateway.all.refetch({ workspaceId });
+      setOpen(false);
+      setName('');
+      navigate({
+        to: '/aiGateway/$gatewayId',
+        params: { gatewayId: duplicate.id },
+      });
+    } catch {
+      // Mutation errors are displayed by defaultErrorHandler.
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild={true}>
+        <Button
+          size="icon"
+          variant="outline"
+          Icon={LuCopy}
+          aria-label={t('Duplicate')}
+          title={t('Duplicate')}
+        />
+      </DialogTrigger>
+      <DialogContent
+        onEscapeKeyDown={(event) => {
+          if (duplicateMutation.isPending) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (duplicateMutation.isPending) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{t('Duplicate AI Gateway')}</DialogTitle>
+          <DialogDescription>
+            {t(
+              'Create a copy of this AI Gateway with the same configuration.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="ai-gateway-duplicate-name" className="text-right">
+              {t('AI Gateway Name')}
+            </Label>
+            <Input
+              id="ai-gateway-duplicate-name"
+              className="col-span-3"
+              value={name}
+              maxLength={100}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            disabled={duplicateMutation.isPending}
+            onClick={() => handleOpenChange(false)}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            aria-label={t('Duplicate gateway')}
+            disabled={!name.trim() || duplicateMutation.isPending}
+            loading={duplicateMutation.isPending}
+            onClick={handleDuplicate}
+          >
+            {t('Duplicate')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/client/routes/aiGateway/$gatewayId/index.tsx
+++ b/src/client/routes/aiGateway/$gatewayId/index.tsx
@@ -3,6 +3,7 @@ import { AIGatewayLogTable } from '@/components/aiGateway/AIGatewayLogTable';
 import { AIGatewayOverview } from '@/components/aiGateway/AIGatewayOverview';
 import { AIGatewayAnalytics } from '@/components/aiGateway/AIGatewayAnalytics';
 import { AIGatewayCodeExampleBtn } from '@/components/aiGateway/AIGatewayCodeExampleBtn';
+import { AIGatewayDuplicateDialog } from '@/components/aiGateway/AIGatewayDuplicateDialog';
 import { useState, useRef } from 'react';
 import { SearchInput } from '@/components/ui/input';
 import { useTranslation } from '@i18next-toolkit/react';
@@ -88,6 +89,11 @@ function PageComponent() {
 
               {hasAdminPermission && (
                 <>
+                  <AIGatewayDuplicateDialog
+                    gatewayId={gatewayId}
+                    gatewayName={gateway.name}
+                  />
+
                   <Button
                     size="icon"
                     variant="outline"

--- a/src/server/trpc/routers/aiGateway.spec.ts
+++ b/src/server/trpc/routers/aiGateway.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     getWorkspaceUser: vi.fn(async () => ({ role: 'owner' })),
     promStartTimer: vi.fn(() => endRequest),
     findGateway: vi.fn(),
+    createGateway: vi.fn(),
     testConnection: vi.fn(),
   };
 });
@@ -38,7 +39,10 @@ vi.mock('../../utils/prometheus/client.js', () => ({
 
 vi.mock('../../model/_client.js', () => ({
   prisma: {
-    aIGateway: { findFirst: mocks.findGateway },
+    aIGateway: {
+      findFirst: mocks.findGateway,
+      create: mocks.createGateway,
+    },
   },
 }));
 
@@ -170,5 +174,96 @@ describe('aiGatewayRouter.testConnection', () => {
       code: 'BAD_GATEWAY',
       message: 'Authentication failed',
     });
+  });
+});
+
+describe('aiGatewayRouter.duplicate', () => {
+  test('rejects a gateway outside the current workspace', async () => {
+    const workspaceId = createId();
+    mocks.findGateway.mockResolvedValue(null);
+    const caller = await createCaller();
+
+    await expect(
+      caller.duplicate({
+        workspaceId,
+        gatewayId: 'gateway_1',
+        name: 'Gateway Copy',
+      })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'AI Gateway not found',
+    });
+
+    expect(mocks.findGateway).toHaveBeenCalledWith({
+      where: { id: 'gateway_1', workspaceId },
+      select: {
+        modelApiKey: true,
+        customModelBaseUrl: true,
+        customModelName: true,
+        customModelStrategy: true,
+        customModelInputPrice: true,
+        customModelOutputPrice: true,
+      },
+    });
+    expect(mocks.createGateway).not.toHaveBeenCalled();
+  });
+
+  test('copies gateway configuration server-side and returns no secret', async () => {
+    const workspaceId = createId();
+    const apiKey = 'sk-sensitive-duplicate';
+    mocks.findGateway.mockResolvedValue({
+      modelApiKey: apiKey,
+      customModelBaseUrl: 'https://models.example.com/v1',
+      customModelName: 'model-a',
+      customModelStrategy: { price: { input: 1 } },
+      customModelInputPrice: 2,
+      customModelOutputPrice: 3,
+    });
+    mocks.createGateway.mockResolvedValue({
+      id: 'gateway_copy',
+      name: 'Gateway Copy',
+    });
+    const caller = await createCaller();
+
+    const result = await caller.duplicate({
+      workspaceId,
+      gatewayId: 'gateway_1',
+      name: '  Gateway Copy  ',
+    });
+
+    expect(mocks.createGateway).toHaveBeenCalledWith({
+      data: {
+        workspaceId,
+        name: 'Gateway Copy',
+        modelApiKey: apiKey,
+        customModelBaseUrl: 'https://models.example.com/v1',
+        customModelName: 'model-a',
+        customModelStrategy: { price: { input: 1 } },
+        customModelInputPrice: 2,
+        customModelOutputPrice: 3,
+      },
+      select: { id: true, name: true },
+    });
+    expect(result).toEqual({ id: 'gateway_copy', name: 'Gateway Copy' });
+    expect(JSON.stringify(result)).not.toContain(apiKey);
+  });
+
+  test.each([
+    ['empty', ''],
+    ['whitespace-only', '   '],
+    ['overlength', 'a'.repeat(101)],
+  ])('rejects a %s gateway name', async (_label, name) => {
+    const caller = await createCaller();
+
+    await expect(
+      caller.duplicate({
+        workspaceId: createId(),
+        gatewayId: 'gateway_1',
+        name,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(mocks.findGateway).not.toHaveBeenCalled();
+    expect(mocks.createGateway).not.toHaveBeenCalled();
   });
 });

--- a/src/server/trpc/routers/aiGateway.ts
+++ b/src/server/trpc/routers/aiGateway.ts
@@ -75,6 +75,11 @@ const aiGatewayCreateSchema = z.object({
   customModelOutputPrice: z.number().nullable(),
 });
 
+const aiGatewayDuplicateOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
 export const aiGatewayRouter = router({
   all: workspaceProcedure
     .meta({
@@ -309,6 +314,57 @@ export const aiGatewayRouter = router({
           cause: error,
         });
       }
+    }),
+
+  duplicate: workspaceAdminProcedure
+    .meta(
+      buildAIGatewayOpenapi({
+        method: 'POST',
+        path: '/duplicate',
+        summary: 'Duplicate gateway',
+      })
+    )
+    .input(
+      z.object({
+        gatewayId: z.string(),
+        name: z.string().trim().min(1).max(100),
+      })
+    )
+    .output(aiGatewayDuplicateOutputSchema)
+    .mutation(async ({ input }) => {
+      const { workspaceId, gatewayId, name } = input;
+      const source = await prisma.aIGateway.findFirst({
+        where: { id: gatewayId, workspaceId },
+        select: {
+          modelApiKey: true,
+          customModelBaseUrl: true,
+          customModelName: true,
+          customModelStrategy: true,
+          customModelInputPrice: true,
+          customModelOutputPrice: true,
+        },
+      });
+
+      if (!source) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'AI Gateway not found',
+        });
+      }
+
+      return prisma.aIGateway.create({
+        data: {
+          workspaceId,
+          name,
+          modelApiKey: source.modelApiKey,
+          customModelBaseUrl: source.customModelBaseUrl,
+          customModelName: source.customModelName,
+          customModelStrategy: source.customModelStrategy,
+          customModelInputPrice: source.customModelInputPrice,
+          customModelOutputPrice: source.customModelOutputPrice,
+        },
+        select: { id: true, name: true },
+      });
     }),
 
   delete: workspaceAdminProcedure


### PR DESCRIPTION
## Background
Admins need a safe way to duplicate an AI Gateway while preserving model configuration and API keys without exposing secrets through the browser.

## Changes
- Add a secure `aiGateway.duplicate` admin mutation that copies selected gateway configuration server-side.
- Return only the duplicated gateway ID and name from the mutation.
- Add an AI Gateway duplicate dialog with default copy naming, validation, pending-state handling, refetch, and navigation.
- Show the duplicate action only for workspace administrators on the gateway detail page.
- Add design and implementation plan docs for the duplicate workflow.

## Testing
Includes server router tests for workspace isolation, name validation, config copying, and secret-safe response shape. Includes client component tests for dialog submission, navigation, pending/error behavior, default name bounds, and admin-only visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace administrators can duplicate an AI Gateway from its detail page.
  - The duplication dialog provides a prefilled “Copy” name with validation.
  - After successful duplication, the new gateway opens automatically.
  - Gateway configuration is copied without exposing sensitive API credentials.

- **Bug Fixes**
  - Added validation and error handling for missing gateways and invalid names.

- **Tests**
  - Added coverage for permissions, validation, successful duplication, failures, and pending states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->