### PR TITLE
fix(ai-gateway): sync summary stats date range

### DIFF
--- a/src/client/components/aiGateway/AIGatewayOverview.tsx
+++ b/src/client/components/aiGateway/AIGatewayOverview.tsx
@@ -161,7 +161,12 @@ export const AIGatewayOverview: React.FC<AIGatewayOverviewProps> = React.memo(
           </div>
         </div>
 
-        <AIGatewaySummaryStats gatewayId={props.gatewayId} />
+        <AIGatewaySummaryStats
+          gatewayId={props.gatewayId}
+          startDate={startDate}
+          endDate={endDate}
+          unit={unit}
+        />
 
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
           <div className="lg:col-span-2">

--- a/src/client/components/aiGateway/AIGatewaySummaryStats.tsx
+++ b/src/client/components/aiGateway/AIGatewaySummaryStats.tsx
@@ -1,21 +1,25 @@
 import React from 'react';
+import { Dayjs } from 'dayjs';
 import { trpc } from '../../api/trpc';
 import { useCurrentWorkspaceId } from '../../store/user';
 import { Card } from '../ui/card';
 import { useTranslation } from '@i18next-toolkit/react';
-import { useGlobalRangeDate } from '@/hooks/useGlobalRangeDate';
+import { DateUnit } from '../../utils/date';
 import { getUserTimezone } from '@/api/model/user';
 import { LoadingView } from '../LoadingView';
 
 interface AIGatewaySummaryStatsProps {
   gatewayId: string;
+  startDate: Dayjs;
+  endDate: Dayjs;
+  unit: DateUnit;
 }
 
 export const AIGatewaySummaryStats: React.FC<AIGatewaySummaryStatsProps> =
   React.memo((props) => {
     const { t } = useTranslation();
     const workspaceId = useCurrentWorkspaceId();
-    const { startDate, endDate, unit } = useGlobalRangeDate();
+    const { startDate, endDate, unit } = props;
 
     const { data: summaryData = [], isLoading } = trpc.insights.query.useQuery(
       {


### PR DESCRIPTION
## Background
Summary stats in the AI Gateway overview should reflect the same selected date range as the surrounding overview charts and filters.

## Changes
- Pass the overview `startDate`, `endDate`, and `unit` into `AIGatewaySummaryStats`.
- Update `AIGatewaySummaryStats` to use the provided date range instead of reading the global range independently.

## Testing
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Summary statistics now consistently reflect the date range and time unit selected in the AI Gateway overview.
  * Improved synchronization between the overview’s global date filters and displayed gateway metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->