### PR TITLE
feat(ai-gateway): group actions under more menu

### DIFF
--- a/docs/superpowers/plans/2026-07-19-ai-gateway-more-menu.md
+++ b/docs/superpowers/plans/2026-07-19-ai-gateway-more-menu.md
@@ -1,0 +1,356 @@
+# AI Gateway More Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Code Example directly visible while grouping the administrator-only Edit, Duplicate, and Delete actions into one accessible More menu on the AI Gateway detail page.
+
+**Architecture:** Convert `AIGatewayDuplicateDialog` into a controlled dialog, then add a focused `AIGatewayActionsMenu` that owns dropdown and duplicate-dialog state. The detail route keeps permission gating, navigation, and deletion side effects and passes callbacks into the menu.
+
+**Tech Stack:** React 18, TypeScript, TanStack Router, Radix dropdown/dialog components, React Icons, Vitest, Testing Library.
+
+## Global Constraints
+
+- Code Example remains directly visible and is not moved into the menu.
+- The More menu and all three actions remain administrator-only.
+- Menu order is Edit, Duplicate, Delete; Delete retains confirmation and destructive styling.
+- Existing duplicate and delete server contracts do not change.
+- Do not modify JSON files under `src/client/public/locales`.
+- Follow TDD: add each behavior test and observe the expected failure before production edits.
+
+---
+
+### Task 1: Make the duplicate dialog controllable by an actions menu
+
+**Files:**
+- Modify: `src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx`
+- Test: `src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx`
+
+**Interfaces:**
+- Consumes: `gatewayId: string`, `gatewayName: string`, `open: boolean`, and `onOpenChange: (open: boolean) => void`.
+- Produces: a triggerless controlled `AIGatewayDuplicateDialog` whose mutation payload and success behavior are unchanged.
+
+- [ ] **Step 1: Change the component tests to drive the controlled interface**
+
+Add a small stateful harness and replace clicks on the old standalone Duplicate trigger with the harness trigger:
+
+```tsx
+function DuplicateDialogHarness(props: {
+  gatewayId?: string;
+  gatewayName?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open duplicate dialog</button>
+      <AIGatewayDuplicateDialog
+        gatewayId={props.gatewayId ?? 'gateway_1'}
+        gatewayName={props.gatewayName ?? 'Primary Gateway'}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}
+```
+
+Update each render to use `DuplicateDialogHarness`, click `Open duplicate dialog`, and keep the existing assertions for bounded default name, safe payload, pending behavior, retry state, refresh, and navigation. Add an assertion that the dialog itself no longer renders a second standalone button named `Duplicate` while closed.
+
+- [ ] **Step 2: Run the focused dialog test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir src/client test --run --config vitest.component.config.ts components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+```
+
+Expected: FAIL because `AIGatewayDuplicateDialog` does not accept `open` or `onOpenChange` and still owns a `DialogTrigger`.
+
+- [ ] **Step 3: Implement the controlled duplicate dialog**
+
+Change the props and dialog shell to this interface:
+
+```tsx
+interface AIGatewayDuplicateDialogProps {
+  gatewayId: string;
+  gatewayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AIGatewayDuplicateDialog({
+  gatewayId,
+  gatewayName,
+  open,
+  onOpenChange,
+}: AIGatewayDuplicateDialogProps) {
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    setName(open ? buildDuplicateName(gatewayName) : '');
+  }, [gatewayName, open]);
+
+  const handleOpenChange = useEvent((nextOpen: boolean) => {
+    if (duplicateMutation.isPending) {
+      return;
+    }
+    onOpenChange(nextOpen);
+  });
+}
+```
+
+Remove `DialogTrigger`, the standalone icon button, and the now-unused `LuCopy` import. Keep the existing `<Dialog open={open} onOpenChange={handleOpenChange}>` content. In the success path, replace the internal close/reset calls:
+
+```tsx
+onOpenChange(false);
+```
+
+Retain the existing safe mutation input, list refetch, and navigation. Do not call `onOpenChange(false)` in the catch path so the entered name remains available for retry.
+
+- [ ] **Step 4: Run the focused dialog test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all `AIGatewayDuplicateDialog` component tests PASS with no warnings.
+
+- [ ] **Step 5: Commit the controlled-dialog change**
+
+```bash
+git add src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+git diff --cached --check
+git commit -m "refactor(ai-gateway): control duplicate dialog"
+```
+
+---
+
+### Task 2: Add the AI Gateway More menu and wire the detail route
+
+**Files:**
+- Create: `src/client/components/aiGateway/AIGatewayActionsMenu.tsx`
+- Create: `src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx`
+- Modify: `src/client/routes/aiGateway/$gatewayId/index.tsx`
+- Modify: `src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx`
+
+**Interfaces:**
+- Consumes: controlled `AIGatewayDuplicateDialog` from Task 1 and callbacks supplied by the detail route.
+- Produces: `AIGatewayActionsMenu({ gatewayId, gatewayName, onEdit, onDelete })`.
+
+- [ ] **Step 1: Write failing actions-menu component tests**
+
+Create tests that render:
+
+```tsx
+<AIGatewayActionsMenu
+  gatewayId="gateway_1"
+  gatewayName="Primary Gateway"
+  onEdit={mocks.onEdit}
+  onDelete={mocks.onDelete}
+/>
+```
+
+Verify the trigger is `getByRole('button', { name: 'More' })`; after opening it, verify Edit, Duplicate, and Delete appear in DOM order. Click Edit and expect `onEdit` once. Click Duplicate and expect a mocked controlled `AIGatewayDuplicateDialog` to receive `open: true`. For Delete, make the `AlertConfirm` mock expose a `Confirm delete` button and verify `onDelete` is untouched on menu selection and called only after confirmation.
+
+- [ ] **Step 2: Run the actions-menu test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir src/client test --run --config vitest.component.config.ts components/aiGateway/AIGatewayActionsMenu.component.spec.tsx
+```
+
+Expected: FAIL because `AIGatewayActionsMenu.tsx` does not exist.
+
+- [ ] **Step 3: Implement the focused actions-menu component**
+
+Create the component with this public contract and structure:
+
+```tsx
+interface AIGatewayActionsMenuProps {
+  gatewayId: string;
+  gatewayName: string;
+  onEdit: () => void;
+  onDelete: () => Promise<void>;
+}
+
+export function AIGatewayActionsMenu(props: AIGatewayActionsMenuProps) {
+  const { t } = useTranslation();
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild={true}>
+          <Button
+            variant="outline"
+            size="icon"
+            Icon={LuEllipsisVertical}
+            aria-label={t('More')}
+            title={t('More')}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={props.onEdit}>
+            <LuPencil className="mr-2" />
+            {t('Edit')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDuplicateOpen(true)}>
+            <LuCopy className="mr-2" />
+            {t('Duplicate')}
+          </DropdownMenuItem>
+          <AlertConfirm
+            title={`${t('Delete AI Gateway')} ${props.gatewayName}`}
+            description={t(
+              'Are you sure you want to delete this AI Gateway? This action cannot be undone.'
+            )}
+            onConfirm={props.onDelete}
+          >
+            <DropdownMenuItem
+              onSelect={(event) => event.preventDefault()}
+              className="text-red-600 data-[highlighted]:!bg-red-50 data-[highlighted]:!text-red-700"
+            >
+              <LuTrash className="mr-2" />
+              {t('Delete')}
+            </DropdownMenuItem>
+          </AlertConfirm>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AIGatewayDuplicateDialog
+        gatewayId={props.gatewayId}
+        gatewayName={props.gatewayName}
+        open={duplicateOpen}
+        onOpenChange={setDuplicateOpen}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run the actions-menu test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all actions-menu tests PASS and confirm menu order, duplicate state, edit callback, and delete confirmation.
+
+- [ ] **Step 5: Write the failing detail-route integration tests**
+
+Replace the duplicate-dialog mock with an `AIGatewayActionsMenu` mock carrying `aria-label="AI Gateway actions"`. Update the two existing tests to assert:
+
+```tsx
+expect(screen.getByText('Code example')).toBeInTheDocument();
+expect(screen.getByLabelText('AI Gateway actions')).toBeInTheDocument();
+```
+
+for administrators, and:
+
+```tsx
+expect(screen.getByText('Code example')).toBeInTheDocument();
+expect(screen.queryByLabelText('AI Gateway actions')).not.toBeInTheDocument();
+```
+
+for non-administrators. Capture the menu props and assert that invoking `onEdit` navigates to `/aiGateway/$gatewayId/edit` with the current ID and that `onDelete` retains the existing mutation, refetch, and list navigation sequence.
+
+- [ ] **Step 6: Run the detail-route test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir src/client test --run --config vitest.component.config.ts components/aiGateway/AIGatewayDetailRoute.component.spec.tsx
+```
+
+Expected: FAIL because the route still imports and renders three standalone administrator actions rather than `AIGatewayActionsMenu`.
+
+- [ ] **Step 7: Replace standalone route actions with the menu**
+
+Import `AIGatewayActionsMenu`, remove direct imports of `AIGatewayDuplicateDialog`, `AlertConfirm`, `LuPencil`, and `LuTrash`, and define an edit callback:
+
+```tsx
+const handleEditGateway = useEvent(() => {
+  navigate({
+    to: '/aiGateway/$gatewayId/edit',
+    params: { gatewayId },
+  });
+});
+```
+
+Keep Code Example outside the permission gate, then render only:
+
+```tsx
+{hasAdminPermission && (
+  <AIGatewayActionsMenu
+    gatewayId={gatewayId}
+    gatewayName={gateway.name}
+    onEdit={handleEditGateway}
+    onDelete={handleDeleteGateway}
+  />
+)}
+```
+
+- [ ] **Step 8: Run both menu and route tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --dir src/client test --run --config vitest.component.config.ts \
+  components/aiGateway/AIGatewayActionsMenu.component.spec.tsx \
+  components/aiGateway/AIGatewayDetailRoute.component.spec.tsx \
+  components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+```
+
+Expected: all focused AI Gateway component tests PASS.
+
+- [ ] **Step 9: Commit the More-menu integration**
+
+```bash
+git add \
+  src/client/components/aiGateway/AIGatewayActionsMenu.tsx \
+  src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx \
+  src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx \
+  'src/client/routes/aiGateway/$gatewayId/index.tsx'
+git diff --cached --check
+git commit -m "feat(ai-gateway): group actions under more menu"
+```
+
+---
+
+### Task 3: Verify the completed behavior
+
+**Files:**
+- Verify only; no planned production changes.
+
+**Interfaces:**
+- Consumes: the controlled duplicate dialog, actions menu, and detail-route integration from Tasks 1-2.
+- Produces: evidence that focused tests, type checking, and production build pass without locale changes.
+
+- [ ] **Step 1: Run all AI Gateway component tests**
+
+```bash
+pnpm --dir src/client test --run --config vitest.component.config.ts components/aiGateway
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type checking**
+
+```bash
+pnpm check:type
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Run the production build**
+
+```bash
+pnpm build
+```
+
+Expected: exit code 0. If the known generated geo-database step is environment-sensitive, rerun with the repository's established `VERCEL=1 pnpm build` path and report both outcomes exactly.
+
+- [ ] **Step 4: Verify scope and locale safety**
+
+```bash
+git status --short --branch --untracked-files=all
+git diff --check HEAD~2..HEAD
+git diff --name-only HEAD~2..HEAD -- src/client/public/locales
+```
+
+Expected: only the planned docs, AI Gateway component, test, and route files changed; the locale command prints nothing.

--- a/docs/superpowers/specs/2026-07-19-ai-gateway-more-menu-design.md
+++ b/docs/superpowers/specs/2026-07-19-ai-gateway-more-menu-design.md
@@ -1,0 +1,56 @@
+# AI Gateway More Menu Design
+
+## Goal
+
+Reduce clutter in the AI Gateway detail header by grouping the administrator-only Duplicate, Edit, and Delete actions under one More menu. The Code Example action remains directly visible.
+
+## User Experience
+
+The detail header keeps the existing Code Example button. Administrators also see one outlined icon button with a vertical ellipsis and an accessible `More` label. Non-administrators do not see the More button or any of its actions.
+
+Opening the menu shows these items in order:
+
+1. Edit
+2. Duplicate
+3. Delete
+
+Each item retains its existing icon. Delete uses the repository's existing destructive menu-item styling and still requires confirmation before the mutation runs. Edit navigates to the current edit route. Duplicate opens the existing duplicate-name dialog and preserves its current submission, refresh, navigation, and server-side secret-handling behavior.
+
+New UI strings use the existing `t(...)` convention. Files under `src/client/public/locales` are not modified.
+
+## Component Design
+
+Add an AI Gateway-specific actions-menu component rather than placing all menu state in the detail route or introducing a generic CRUD abstraction.
+
+The component receives the current Gateway ID and name plus callbacks for edit and confirmed deletion. It owns the dropdown presentation and the state needed to open the existing duplicate dialog from a menu item. The detail route remains responsible for permission gating, navigation, and deletion because those behaviors already live there.
+
+The duplicate dialog will support being opened from the menu without changing its mutation contract. Its standalone icon trigger is removed from the detail header. No server API or database code changes are required.
+
+## Interaction and Error Handling
+
+- Selecting Edit closes the menu and navigates to `/aiGateway/$gatewayId/edit`.
+- Selecting Duplicate closes the menu and opens the duplicate dialog with the same bounded default name as today.
+- Selecting Delete keeps the destructive action behind `AlertConfirm`; dismissing the confirmation performs no mutation.
+- Duplicate mutation failures continue to use `defaultErrorHandler` and keep the dialog available for retry.
+- Delete mutation and navigation behavior remain unchanged.
+
+## Testing
+
+Use focused component tests to verify:
+
+- Administrators see Code Example and one More button instead of three separate action buttons.
+- Non-administrators see Code Example but not More.
+- Opening More exposes Edit, Duplicate, and Delete in the expected order.
+- Edit invokes navigation to the existing edit route.
+- Duplicate opens the existing dialog flow.
+- Delete remains destructive and invokes deletion only after confirmation.
+
+Run the focused AI Gateway client tests first, followed by the client test suite relevant to this route and `pnpm check:type`. Run `pnpm build` as the final production verification required by the contributor guide.
+
+## Out of Scope
+
+- Moving Code Example into the More menu
+- Changing administrator permissions
+- Changing duplicate or delete server behavior
+- Creating a generic application-wide action-menu abstraction
+- Modifying translation JSON files

--- a/src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AIGatewayActionsMenu } from './AIGatewayActionsMenu';
+
+const mocks = vi.hoisted(() => ({
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  duplicateDialogProps: { current: null as any },
+}));
+
+vi.mock('@i18next-toolkit/react', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/aiGateway/AIGatewayDuplicateDialog', () => ({
+  AIGatewayDuplicateDialog: (props: unknown) => {
+    mocks.duplicateDialogProps.current = props;
+    return null;
+  },
+}));
+
+vi.mock('@/components/AlertConfirm', () => ({
+  AlertConfirm: ({
+    children,
+    onConfirm,
+  }: React.PropsWithChildren<{ onConfirm: () => void }>) => (
+    <div>
+      {children}
+      <button onClick={onConfirm}>Confirm delete</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.onDelete.mockResolvedValue(undefined);
+  mocks.duplicateDialogProps.current = null;
+});
+
+function renderMenu() {
+  render(
+    <AIGatewayActionsMenu
+      gatewayId="gateway_1"
+      gatewayName="Primary Gateway"
+      onEdit={mocks.onEdit}
+      onDelete={mocks.onDelete}
+    />
+  );
+}
+
+async function openMenu() {
+  await userEvent.click(screen.getByRole('button', { name: 'More' }));
+}
+
+describe('AIGatewayActionsMenu', () => {
+  test('shows Edit, Duplicate, and Delete in order', async () => {
+    renderMenu();
+    await openMenu();
+
+    const actions = ['Edit', 'Duplicate', 'Delete'].map((name) =>
+      screen.getByText(name)
+    );
+    expect(actions[0].compareDocumentPosition(actions[1])).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(actions[1].compareDocumentPosition(actions[2])).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
+  test('invokes edit from the menu', async () => {
+    renderMenu();
+    await openMenu();
+
+    await userEvent.click(screen.getByText('Edit'));
+
+    expect(mocks.onEdit).toHaveBeenCalledOnce();
+  });
+
+  test('opens the controlled duplicate dialog from the menu', async () => {
+    renderMenu();
+    expect(mocks.duplicateDialogProps.current).toMatchObject({
+      gatewayId: 'gateway_1',
+      gatewayName: 'Primary Gateway',
+      open: false,
+    });
+
+    await openMenu();
+    await userEvent.click(screen.getByText('Duplicate'));
+
+    expect(mocks.duplicateDialogProps.current).toMatchObject({ open: true });
+  });
+
+  test('deletes only after confirmation', async () => {
+    renderMenu();
+    await openMenu();
+
+    await userEvent.click(screen.getByText('Delete'));
+    expect(mocks.onDelete).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Confirm delete' })
+    );
+    expect(mocks.onDelete).toHaveBeenCalledOnce();
+  });
+});

--- a/src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayActionsMenu.component.spec.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   onEdit: vi.fn(),
   onDelete: vi.fn(),
   duplicateDialogProps: { current: null as any },
+  useRealAlertConfirm: false,
 }));
 
 vi.mock('@i18next-toolkit/react', () => ({
@@ -22,22 +23,39 @@ vi.mock('@/components/aiGateway/AIGatewayDuplicateDialog', () => ({
   },
 }));
 
-vi.mock('@/components/AlertConfirm', () => ({
-  AlertConfirm: ({
-    children,
-    onConfirm,
-  }: React.PropsWithChildren<{ onConfirm: () => void }>) => (
-    <div>
-      {children}
-      <button onClick={onConfirm}>Confirm delete</button>
-    </div>
-  ),
-}));
+vi.mock('@/components/AlertConfirm', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/components/AlertConfirm')>();
+
+  return {
+    AlertConfirm: ({
+      children,
+      onConfirm,
+      ...props
+    }: React.ComponentProps<typeof actual.AlertConfirm>) => {
+      if (mocks.useRealAlertConfirm) {
+        return (
+          <actual.AlertConfirm onConfirm={onConfirm} {...props}>
+            {children}
+          </actual.AlertConfirm>
+        );
+      }
+
+      return (
+        <div>
+          {children}
+          <button onClick={onConfirm}>Confirm delete</button>
+        </div>
+      );
+    },
+  };
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.onDelete.mockResolvedValue(undefined);
   mocks.duplicateDialogProps.current = null;
+  mocks.useRealAlertConfirm = false;
 });
 
 function renderMenu() {
@@ -104,6 +122,25 @@ describe('AIGatewayActionsMenu', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Confirm delete' })
     );
+    expect(mocks.onDelete).toHaveBeenCalledOnce();
+  });
+
+  test('opens the real delete confirmation before deleting', async () => {
+    mocks.useRealAlertConfirm = true;
+    renderMenu();
+    await openMenu();
+
+    await userEvent.click(screen.getByText('Delete'));
+
+    expect(
+      await screen.findByRole('alertdialog', {
+        name: 'Delete AI Gateway Primary Gateway',
+      })
+    ).toBeInTheDocument();
+    expect(mocks.onDelete).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
     expect(mocks.onDelete).toHaveBeenCalledOnce();
   });
 });

--- a/src/client/components/aiGateway/AIGatewayActionsMenu.tsx
+++ b/src/client/components/aiGateway/AIGatewayActionsMenu.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { useTranslation } from '@i18next-toolkit/react';
+import { LuCopy, LuEllipsisVertical, LuPencil, LuTrash } from 'react-icons/lu';
+import { AIGatewayDuplicateDialog } from '@/components/aiGateway/AIGatewayDuplicateDialog';
+import { AlertConfirm } from '@/components/AlertConfirm';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface AIGatewayActionsMenuProps {
+  gatewayId: string;
+  gatewayName: string;
+  onEdit: () => void;
+  onDelete: () => Promise<void>;
+}
+
+export function AIGatewayActionsMenu(props: AIGatewayActionsMenuProps) {
+  const { t } = useTranslation();
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild={true}>
+          <Button
+            variant="outline"
+            size="icon"
+            Icon={LuEllipsisVertical}
+            aria-label={t('More')}
+            title={t('More')}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={props.onEdit}>
+            <LuPencil className="mr-2" />
+            {t('Edit')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDuplicateOpen(true)}>
+            <LuCopy className="mr-2" />
+            {t('Duplicate')}
+          </DropdownMenuItem>
+          <AlertConfirm
+            title={`${t('Delete AI Gateway')} ${props.gatewayName}`}
+            description={t(
+              'Are you sure you want to delete this AI Gateway? This action cannot be undone.'
+            )}
+            onConfirm={props.onDelete}
+          >
+            <DropdownMenuItem
+              onSelect={(event) => event.preventDefault()}
+              className="text-red-600 data-[highlighted]:!bg-red-50 data-[highlighted]:!text-red-700"
+            >
+              <LuTrash className="mr-2" />
+              {t('Delete')}
+            </DropdownMenuItem>
+          </AlertConfirm>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AIGatewayDuplicateDialog
+        gatewayId={props.gatewayId}
+        gatewayName={props.gatewayName}
+        open={duplicateOpen}
+        onOpenChange={setDuplicateOpen}
+      />
+    </>
+  );
+}

--- a/src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayDetailRoute.component.spec.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Route } from '../../routes/aiGateway/$gatewayId/index';
 
 const mocks = vi.hoisted(() => ({
   hasAdminPermission: true,
+  navigate: vi.fn(),
+  deleteGateway: vi.fn(),
+  refetchGateways: vi.fn(),
+  actionsMenuProps: { current: null as any },
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -14,7 +19,7 @@ vi.mock('@tanstack/react-router', () => ({
       ...options,
       useParams: () => ({ gatewayId: 'gateway_1' }),
     }),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mocks.navigate,
 }));
 
 vi.mock('@i18next-toolkit/react', () => ({
@@ -30,7 +35,9 @@ vi.mock('@/store/user', () => ({
 vi.mock('@/api/trpc', () => ({
   defaultErrorHandler: vi.fn(),
   trpc: {
-    useUtils: () => ({ aiGateway: { all: { refetch: vi.fn() } } }),
+    useUtils: () => ({
+      aiGateway: { all: { refetch: mocks.refetchGateways } },
+    }),
     aiGateway: {
       info: {
         useQuery: () => ({
@@ -39,7 +46,7 @@ vi.mock('@/api/trpc', () => ({
         }),
       },
       delete: {
-        useMutation: () => ({ mutateAsync: vi.fn() }),
+        useMutation: () => ({ mutateAsync: mocks.deleteGateway }),
       },
     },
   },
@@ -56,42 +63,65 @@ vi.mock('@/components/CommonHeader', () => ({
 vi.mock('@/components/aiGateway/AIGatewayCodeExampleBtn', () => ({
   AIGatewayCodeExampleBtn: () => <div>Code example</div>,
 }));
-vi.mock('@/components/aiGateway/AIGatewayDuplicateDialog', () => ({
-  AIGatewayDuplicateDialog: () => <div aria-label="Duplicate action" />,
-}));
-vi.mock('@/components/AlertConfirm', () => ({
-  AlertConfirm: ({ children }: React.PropsWithChildren) => <>{children}</>,
-}));
-vi.mock('@/components/ui/button', () => ({
-  Button: ({
-    Icon: _Icon,
-    ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
-    Icon?: React.ComponentType;
-  }) => <button {...props} />,
+vi.mock('@/components/aiGateway/AIGatewayActionsMenu', () => ({
+  AIGatewayActionsMenu: (props: unknown) => {
+    mocks.actionsMenuProps.current = props;
+    return <div aria-label="AI Gateway actions" />;
+  },
 }));
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mocks.hasAdminPermission = true;
+  mocks.actionsMenuProps.current = null;
+  mocks.deleteGateway.mockResolvedValue(undefined);
+  mocks.refetchGateways.mockResolvedValue(undefined);
 });
 
-describe('AI Gateway detail route duplicate action', () => {
-  test('shows the duplicate action to workspace administrators', async () => {
-    const { Route } = await import('../../routes/aiGateway/$gatewayId/index');
+describe('AI Gateway detail route actions', () => {
+  test('shows Code Example and the actions menu to workspace administrators', async () => {
     const Component = (Route as any).component;
 
     render(<Component />);
 
-    expect(screen.getByLabelText('Duplicate action')).toBeInTheDocument();
+    expect(screen.getByText('Code example')).toBeInTheDocument();
+    expect(screen.getByLabelText('AI Gateway actions')).toBeInTheDocument();
+
+    act(() => mocks.actionsMenuProps.current.onEdit());
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/aiGateway/$gatewayId/edit',
+      params: { gatewayId: 'gateway_1' },
+    });
+
+    await act(() => mocks.actionsMenuProps.current.onDelete());
+    expect(mocks.deleteGateway).toHaveBeenCalledWith({
+      workspaceId: 'workspace_1',
+      gatewayId: 'gateway_1',
+    });
+    expect(mocks.refetchGateways).toHaveBeenCalledWith({
+      workspaceId: 'workspace_1',
+    });
+    expect(mocks.navigate).toHaveBeenLastCalledWith({
+      to: '/aiGateway',
+      replace: true,
+    });
+    expect(mocks.deleteGateway.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.refetchGateways.mock.invocationCallOrder[0]
+    );
+    expect(mocks.refetchGateways.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.navigate.mock.invocationCallOrder[1]
+    );
   });
 
-  test('hides the duplicate action from non-administrators', async () => {
+  test('shows Code Example but hides the actions menu from non-administrators', () => {
     mocks.hasAdminPermission = false;
-    const { Route } = await import('../../routes/aiGateway/$gatewayId/index');
     const Component = (Route as any).component;
 
     render(<Component />);
 
-    expect(screen.queryByLabelText('Duplicate action')).not.toBeInTheDocument();
+    expect(screen.getByText('Code example')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('AI Gateway actions')
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.component.spec.tsx
@@ -4,6 +4,25 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { AIGatewayDuplicateDialog } from './AIGatewayDuplicateDialog';
 
+function DuplicateDialogHarness(props: {
+  gatewayId?: string;
+  gatewayName?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open duplicate dialog</button>
+      <AIGatewayDuplicateDialog
+        gatewayId={props.gatewayId ?? 'gateway_1'}
+        gatewayName={props.gatewayName ?? 'Primary Gateway'}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}
+
 const mocks = vi.hoisted(() => ({
   duplicate: vi.fn(),
   refetchGateways: vi.fn(),
@@ -57,15 +76,20 @@ beforeEach(() => {
 });
 
 describe('AIGatewayDuplicateDialog', () => {
-  test('uses a default copy name and submits only safe fields', async () => {
-    render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
-    );
+  test('does not render a standalone duplicate trigger while closed', () => {
+    render(<DuplicateDialogHarness />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    expect(
+      screen.queryByRole('button', { name: 'Duplicate' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('uses a default copy name and submits only safe fields', async () => {
+    render(<DuplicateDialogHarness />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
+    );
     const nameInput = screen.getByLabelText('AI Gateway Name');
     expect(nameInput).toHaveValue('Primary Gateway - Copy');
 
@@ -88,14 +112,11 @@ describe('AIGatewayDuplicateDialog', () => {
   });
 
   test('refreshes the list and navigates to the duplicate on success', async () => {
-    render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
-    );
+    render(<DuplicateDialogHarness />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Duplicate gateway' }));
 
     await waitFor(() => {
@@ -113,14 +134,11 @@ describe('AIGatewayDuplicateDialog', () => {
   });
 
   test('does not submit an empty name', () => {
-    render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
-    );
+    render(<DuplicateDialogHarness />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
+    );
     fireEvent.change(screen.getByLabelText('AI Gateway Name'), {
       target: { value: '   ' },
     });
@@ -133,13 +151,12 @@ describe('AIGatewayDuplicateDialog', () => {
 
   test('keeps the default copy name within the server length limit', () => {
     render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName={'a'.repeat(100)}
-      />
+      <DuplicateDialogHarness gatewayName={'a'.repeat(100)} />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
+    );
 
     const defaultName = screen.getByLabelText('AI Gateway Name').getAttribute(
       'value'
@@ -149,21 +166,13 @@ describe('AIGatewayDuplicateDialog', () => {
   });
 
   test('prevents closing or resubmitting while pending', () => {
-    const { rerender } = render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
+    const { rerender } = render(<DuplicateDialogHarness />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
 
     mocks.isPending = true;
-    rerender(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
-    );
+    rerender(<DuplicateDialogHarness />);
 
     expect(
       screen.getByRole('button', { name: 'Duplicate gateway' })
@@ -178,14 +187,11 @@ describe('AIGatewayDuplicateDialog', () => {
 
   test('keeps the dialog and entered name when duplication fails', async () => {
     mocks.duplicate.mockRejectedValue(new Error('database unavailable'));
-    render(
-      <AIGatewayDuplicateDialog
-        gatewayId="gateway_1"
-        gatewayName="Primary Gateway"
-      />
-    );
+    render(<DuplicateDialogHarness />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open duplicate dialog' })
+    );
     const nameInput = screen.getByLabelText('AI Gateway Name');
     fireEvent.change(nameInput, { target: { value: 'Retry Name' } });
     fireEvent.click(screen.getByRole('button', { name: 'Duplicate gateway' }));

--- a/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
+++ b/src/client/components/aiGateway/AIGatewayDuplicateDialog.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from '@i18next-toolkit/react';
-import { LuCopy } from 'react-icons/lu';
 import { defaultErrorHandler, trpc } from '@/api/trpc';
 import { useEvent } from '@/hooks/useEvent';
 import { useCurrentWorkspaceId } from '@/store/user';
@@ -13,7 +12,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -21,6 +19,8 @@ import { Label } from '@/components/ui/label';
 interface AIGatewayDuplicateDialogProps {
   gatewayId: string;
   gatewayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 const MAX_GATEWAY_NAME_LENGTH = 100;
@@ -36,25 +36,29 @@ function buildDuplicateName(gatewayName: string) {
 export function AIGatewayDuplicateDialog({
   gatewayId,
   gatewayName,
+  open,
+  onOpenChange,
 }: AIGatewayDuplicateDialogProps) {
   const { t } = useTranslation();
   const workspaceId = useCurrentWorkspaceId();
   const navigate = useNavigate();
   const trpcUtils = trpc.useUtils();
-  const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
 
   const duplicateMutation = trpc.aiGateway.duplicate.useMutation({
     onError: defaultErrorHandler,
   });
 
+  useEffect(() => {
+    setName(open ? buildDuplicateName(gatewayName) : '');
+  }, [gatewayName, open]);
+
   const handleOpenChange = useEvent((nextOpen: boolean) => {
     if (duplicateMutation.isPending) {
       return;
     }
 
-    setOpen(nextOpen);
-    setName(nextOpen ? buildDuplicateName(gatewayName) : '');
+    onOpenChange(nextOpen);
   });
 
   const handleDuplicate = useEvent(async () => {
@@ -71,8 +75,7 @@ export function AIGatewayDuplicateDialog({
       });
 
       await trpcUtils.aiGateway.all.refetch({ workspaceId });
-      setOpen(false);
-      setName('');
+      onOpenChange(false);
       navigate({
         to: '/aiGateway/$gatewayId',
         params: { gatewayId: duplicate.id },
@@ -84,15 +87,6 @@ export function AIGatewayDuplicateDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild={true}>
-        <Button
-          size="icon"
-          variant="outline"
-          Icon={LuCopy}
-          aria-label={t('Duplicate')}
-          title={t('Duplicate')}
-        />
-      </DialogTrigger>
       <DialogContent
         onEscapeKeyDown={(event) => {
           if (duplicateMutation.isPending) {

--- a/src/client/routes/aiGateway/$gatewayId/index.tsx
+++ b/src/client/routes/aiGateway/$gatewayId/index.tsx
@@ -3,14 +3,13 @@ import { AIGatewayLogTable } from '@/components/aiGateway/AIGatewayLogTable';
 import { AIGatewayOverview } from '@/components/aiGateway/AIGatewayOverview';
 import { AIGatewayAnalytics } from '@/components/aiGateway/AIGatewayAnalytics';
 import { AIGatewayCodeExampleBtn } from '@/components/aiGateway/AIGatewayCodeExampleBtn';
-import { AIGatewayDuplicateDialog } from '@/components/aiGateway/AIGatewayDuplicateDialog';
+import { AIGatewayActionsMenu } from '@/components/aiGateway/AIGatewayActionsMenu';
 import { useState, useRef } from 'react';
 import { SearchInput } from '@/components/ui/input';
 import { useTranslation } from '@i18next-toolkit/react';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { trpc, defaultErrorHandler } from '@/api/trpc';
-import { AlertConfirm } from '@/components/AlertConfirm';
 import { Button } from '@/components/ui/button';
 import { CommonWrapper } from '@/components/CommonWrapper';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -20,7 +19,7 @@ import { Loading } from '@/components/Loading';
 import { useCurrentWorkspaceId, useHasAdminPermission } from '@/store/user';
 import { routeAuthBeforeLoad } from '@/utils/route';
 import { useNavigate } from '@tanstack/react-router';
-import { LuPencil, LuTrash, LuRefreshCw } from 'react-icons/lu';
+import { LuRefreshCw } from 'react-icons/lu';
 import { message } from 'antd';
 import { NotFoundTip } from '@/components/NotFoundTip';
 import { useEvent } from '@/hooks/useEvent';
@@ -66,6 +65,13 @@ function PageComponent() {
     });
   });
 
+  const handleEditGateway = useEvent(() => {
+    navigate({
+      to: '/aiGateway/$gatewayId/edit',
+      params: { gatewayId },
+    });
+  });
+
   if (!gatewayId) {
     return <ErrorTip />;
   }
@@ -88,36 +94,12 @@ function PageComponent() {
               <AIGatewayCodeExampleBtn gatewayId={gatewayId} />
 
               {hasAdminPermission && (
-                <>
-                  <AIGatewayDuplicateDialog
-                    gatewayId={gatewayId}
-                    gatewayName={gateway.name}
-                  />
-
-                  <Button
-                    size="icon"
-                    variant="outline"
-                    Icon={LuPencil}
-                    onClick={() =>
-                      navigate({
-                        to: '/aiGateway/$gatewayId/edit',
-                        params: {
-                          gatewayId,
-                        },
-                      })
-                    }
-                  />
-
-                  <AlertConfirm
-                    title={t('Delete AI Gateway') + ' ' + gateway.name}
-                    description={t(
-                      'Are you sure you want to delete this AI Gateway? This action cannot be undone.'
-                    )}
-                    onConfirm={handleDeleteGateway}
-                  >
-                    <Button size="icon" variant="outline" Icon={LuTrash} />
-                  </AlertConfirm>
-                </>
+                <AIGatewayActionsMenu
+                  gatewayId={gatewayId}
+                  gatewayName={gateway.name}
+                  onEdit={handleEditGateway}
+                  onDelete={handleDeleteGateway}
+                />
               )}
             </div>
           }


### PR DESCRIPTION
## Background

Reduce clutter in the AI Gateway detail header while keeping Code Example directly visible and preserving admin-only gateway actions.

## Changes

- Add an AI Gateway actions menu that groups Edit, Duplicate, and Delete under a More button.
- Refactor the duplicate dialog into a controlled component so it can be opened from the menu.
- Keep Delete behind the existing confirmation flow with destructive styling.
- Preserve admin permission gating in the detail route while leaving Code Example visible.
- Add design and implementation docs for the more actions menu.

## Testing

Added focused component coverage for the actions menu, duplicate dialog control flow, detail route integration, and delete confirmation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **More** menu to AI Gateway details for administrators.
  * Grouped Edit, Duplicate, and Delete actions in the menu.
  * Kept the Code Example action visible outside the menu.
  * Added confirmation protection for gateway deletion.
  * Updated duplicate gateway dialogs to open and close through the menu.

* **Tests**
  * Added coverage for menu ordering, permissions, navigation, duplication, and deletion confirmation.

* **Documentation**
  * Added design and implementation documentation for the AI Gateway actions menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->