### PR TITLE
feat(worker): synchronize cron lifecycle across instances

### DIFF
--- a/docs/superpowers/plans/2026-07-31-worker-cron-lifecycle-sync.md
+++ b/docs/superpowers/plans/2026-07-31-worker-cron-lifecycle-sync.md
@@ -1,0 +1,504 @@
+# Worker Cron Lifecycle Synchronization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Synchronize Worker cron schedules and captured Worker code across Tianji server instances through an optional Worker-specific Redis lifecycle broadcast.
+
+**Architecture:** Add a `WorkerCronBroadcast` parallel to `MonitorBroadcast`. PostgreSQL remains authoritative: every local mutation persists first and every remote event reloads the complete Worker row before replacing or removing the process-local runner. `WorkerCronManager` serializes lifecycle work per Worker ID and performs full reconciliation at startup and Redis recovery.
+
+**Tech Stack:** TypeScript 5.7, Node.js 22.14.0+, Prisma 5, ioredis 5, Zod 4, Vitest 3, pnpm 9.7.1
+
+## Global Constraints
+
+- Use Redis channel `tianji:worker:cron:lifecycle`.
+- Enable broadcasting only when `env.cache.redisUrl` is present.
+- Keep PostgreSQL authoritative; Redis events contain identifiers and action metadata only.
+- Log Redis failures without rejecting successful PostgreSQL mutations.
+- Preserve single-instance and Redis-disabled behavior.
+- Do not refactor or modify Monitor broadcast behavior.
+- Do not modify JSON files under `src/client/public/locales`.
+- Redis Pub/Sub remains best-effort; durable delivery and periodic reconciliation are out of scope.
+
+---
+
+### Task 1: Worker-specific Redis lifecycle transport
+
+**Files:**
+- Create: `src/server/model/worker/broadcast.spec.ts`
+- Create: `src/server/model/worker/broadcast.ts`
+
+**Interfaces:**
+- Produces `WORKER_CRON_BROADCAST_CHANNEL`.
+- Produces `WorkerCronBroadcastAction = 'create' | 'update' | 'start' | 'stop' | 'delete'`.
+- Produces `WorkerCronBroadcastEvent` with `workspaceId`, `workerId`, and `sourceInstanceId`.
+- Produces `WorkerCronBroadcast.start(handler, recover, readinessTimeoutMs?)`, `publish(action, workspaceId, workerId)`, and `close()`.
+- Produces singleton `workerCronBroadcast`.
+
+- [ ] **Step 1: Write failing transport tests**
+
+Create a fake Redis client with real listener registration and observable
+`subscribe`, `publish`, and `quit` methods. Add tests that exercise:
+
+```ts
+test('does not construct redis clients without a redis url', async () => {
+  const createClient = vi.fn();
+  const broadcast = new WorkerCronBroadcast(
+    undefined,
+    'instance-a',
+    createClient
+  );
+
+  await expect(
+    broadcast.start(vi.fn(), vi.fn(), 50)
+  ).resolves.toBe(true);
+  expect(createClient).not.toHaveBeenCalled();
+});
+
+test('delivers valid worker messages from another instance', async () => {
+  const { broadcast, subscriber } = createHarness();
+  const handler = vi.fn();
+  await broadcast.start(handler, vi.fn(), 50);
+
+  subscriber.emitMessage({
+    action: 'update',
+    workspaceId: 'workspace-a',
+    workerId: 'worker-a',
+    sourceInstanceId: 'instance-b',
+  });
+
+  expect(handler).toHaveBeenCalledWith({
+    action: 'update',
+    workspaceId: 'workspace-a',
+    workerId: 'worker-a',
+    sourceInstanceId: 'instance-b',
+  });
+});
+
+test('ignores self-originated and malformed messages', async () => {
+  const { broadcast, subscriber } = createHarness();
+  const handler = vi.fn();
+  await broadcast.start(handler, vi.fn(), 50);
+
+  subscriber.emitMessage({
+    action: 'update',
+    workspaceId: 'workspace-a',
+    workerId: 'worker-a',
+    sourceInstanceId: 'instance-a',
+  });
+  subscriber.emitRaw('{');
+  subscriber.emitRaw(JSON.stringify({ action: 'update' }));
+
+  expect(handler).not.toHaveBeenCalled();
+});
+
+test('publishes the worker event with the current instance id', async () => {
+  const { broadcast, publisher } = createHarness();
+  await broadcast.start(vi.fn(), vi.fn(), 50);
+
+  await broadcast.publish('update', 'workspace-a', 'worker-a');
+
+  expect(publisher.publish).toHaveBeenCalledWith(
+    WORKER_CRON_BROADCAST_CHANNEL,
+    JSON.stringify({
+      action: 'update',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-a',
+    })
+  );
+});
+```
+
+Also cover successful initial subscription without recovery, reconnect recovery,
+subscription timeout, retry after `ready`, concurrent `start`, concurrent
+`close`, ignored activity after `close`, and absorbed subscription, handler,
+publish, recovery, and cleanup errors. These are the existing
+`MonitorBroadcast` transport contracts applied to the independent Worker
+channel and event schema.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir src/server exec vitest run model/worker/broadcast.spec.ts
+```
+
+Expected: FAIL because `model/worker/broadcast.ts` does not exist.
+
+- [ ] **Step 3: Implement the minimal Worker transport**
+
+Create the Worker event contract:
+
+```ts
+export const WORKER_CRON_BROADCAST_CHANNEL =
+  'tianji:worker:cron:lifecycle';
+
+export type WorkerCronBroadcastAction =
+  | 'create'
+  | 'update'
+  | 'start'
+  | 'stop'
+  | 'delete';
+
+export interface WorkerCronBroadcastEvent {
+  action: WorkerCronBroadcastAction;
+  workspaceId: string;
+  workerId: string;
+  sourceInstanceId: string;
+}
+```
+
+Implement `WorkerCronBroadcast` with the same optional-client, readiness,
+reconnect recovery, validation, self-filtering, error isolation, and idempotent
+shutdown behavior as `MonitorBroadcast`, but use only the Worker channel and
+Worker event schema. Construct the singleton with:
+
+```ts
+export const workerCronBroadcast = new WorkerCronBroadcast(
+  env.cache.redisUrl,
+  nanoid(),
+  (url) => new Redis(url)
+);
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Step 2 command. Expected: all Worker transport tests PASS.
+
+- [ ] **Step 5: Commit the transport**
+
+```bash
+git add src/server/model/worker/broadcast.ts \
+  src/server/model/worker/broadcast.spec.ts
+git commit -m "feat(worker): add cron lifecycle broadcast"
+```
+
+---
+
+### Task 2: Database-authoritative Worker runner reconciliation
+
+**Files:**
+- Create: `src/server/model/worker/cronManager.spec.ts`
+- Modify: `src/server/model/worker/cronManager.ts`
+
+**Interfaces:**
+- Consumes `workerCronBroadcast` and `WorkerCronBroadcastEvent`.
+- Produces `reconcile(workspaceId, workerId): Promise<void>`.
+- Produces `reconcileAll(): Promise<void>`.
+- Produces `handleBroadcast(event): Promise<void>`.
+- Local `upsert` and `delete` serialize through the same per-Worker queue.
+
+- [ ] **Step 1: Write failing stale-runner and concurrency tests**
+
+Mock only Prisma, `WorkerCronRunner`, cache invalidation, and the external
+broadcast boundary. The fake runner must retain the complete Worker fixture so
+the test observes the stale-code bug through the real manager behavior.
+
+Use Worker fixtures whose relevant fields differ:
+
+```ts
+const oldWorker = {
+  ...activeWorker,
+  code: 'return "old";',
+  cronExpression: '*/5 * * * *',
+  revision: 1,
+};
+
+const updatedWorker = {
+  ...activeWorker,
+  code: 'return "new";',
+  cronExpression: '*/30 * * * *',
+  revision: 2,
+};
+```
+
+Add the primary regression test:
+
+```ts
+test('remote update replaces stale cron expression and worker code', async () => {
+  const manager = new WorkerCronManager();
+  const oldRunner = seedRunner(manager, oldWorker);
+  mocks.prisma.functionWorker.findUnique.mockResolvedValue(updatedWorker);
+
+  await manager.handleBroadcast(remoteEvent('update'));
+
+  expect(oldRunner.stopCron).toHaveBeenCalledOnce();
+  expect(mocks.runnerInstances).toHaveLength(2);
+  expect(mocks.runnerInstances[1].worker.cronExpression)
+    .toBe('*/30 * * * *');
+  expect(mocks.runnerInstances[1].worker.code).toBe('return "new";');
+  expect(mocks.runnerInstances[1].startCron).toHaveBeenCalledOnce();
+  expect(manager.getRunner('worker-a')).toBe(mocks.runnerInstances[1]);
+});
+```
+
+Add reconciliation behavior:
+
+```ts
+test.each([
+  null,
+  { ...updatedWorker, active: false },
+  { ...updatedWorker, enableCron: false },
+  { ...updatedWorker, cronExpression: null },
+])('remote event removes a runner for non-runnable state %#', async (state) => {
+  const manager = new WorkerCronManager();
+  const oldRunner = seedRunner(manager, oldWorker);
+  mocks.prisma.functionWorker.findUnique.mockResolvedValue(state);
+
+  await manager.handleBroadcast(remoteEvent('delete'));
+
+  expect(oldRunner.stopCron).toHaveBeenCalledOnce();
+  expect(manager.getRunner('worker-a')).toBeUndefined();
+});
+```
+
+Add tests proving:
+
+- Same-Worker reconciliations serialize, while different Workers do not.
+- A rejected operation does not poison the Worker queue.
+- `reconcileAll()` starts a missing active cron runner and stops a stale local
+  runner absent from the runnable database set.
+- Successful create and update publish only after PostgreSQL succeeds.
+- Successful deletion stops the local runner and publishes `delete` only after
+  PostgreSQL succeeds.
+- Failed deletion preserves the local runner and does not publish.
+
+- [ ] **Step 2: Run manager tests and verify RED**
+
+Run:
+
+```bash
+pnpm --dir src/server exec vitest run model/worker/cronManager.spec.ts
+```
+
+Expected: FAIL because `handleBroadcast`, `reconcile`, `reconcileAll`, queueing,
+and publishing do not exist.
+
+- [ ] **Step 3: Add the per-Worker lifecycle queue**
+
+Add:
+
+```ts
+private lifecycleTails = new Map<string, Promise<void>>();
+
+private runLifecycle<T>(
+  workerId: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = this.lifecycleTails.get(workerId) ?? Promise.resolve();
+  const result = previous.catch(() => undefined).then(operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined
+  );
+  this.lifecycleTails.set(workerId, tail);
+
+  return result.finally(() => {
+    if (this.lifecycleTails.get(workerId) === tail) {
+      this.lifecycleTails.delete(workerId);
+    }
+  });
+}
+```
+
+Wrap update, delete, and remote reconciliation with this queue. After a create
+returns its generated ID, use the same queue to publish and apply local state.
+
+- [ ] **Step 4: Implement authoritative reconciliation**
+
+Add an unqueued lookup and state application:
+
+```ts
+private async reconcileUnlocked(
+  workspaceId: string,
+  workerId: string
+): Promise<void> {
+  const worker = await prisma.functionWorker.findUnique({
+    where: { id: workerId, workspaceId },
+  });
+
+  if (
+    !worker?.active ||
+    !worker.enableCron ||
+    !worker.cronExpression
+  ) {
+    await this.removeRunner(workerId);
+    return;
+  }
+
+  await this.applyWorkerStateUnlocked(worker);
+}
+
+async reconcile(workspaceId: string, workerId: string): Promise<void> {
+  return this.runLifecycle(workerId, () =>
+    this.reconcileUnlocked(workspaceId, workerId)
+  );
+}
+
+async handleBroadcast(event: WorkerCronBroadcastEvent): Promise<void> {
+  await this.reconcile(event.workspaceId, event.workerId);
+}
+```
+
+`removeRunner` must stop and delete an existing runner. `applyWorkerStateUnlocked`
+must remove non-runnable state, otherwise create a fresh runner and start it.
+Resolve the workspace before stopping the current runner so a failed workspace
+lookup preserves the valid old runner.
+
+- [ ] **Step 5: Implement full reconciliation and startup reuse**
+
+`reconcileAll()` must query runnable Workers with:
+
+```ts
+{
+  where: {
+    active: true,
+    enableCron: true,
+    cronExpression: { not: null },
+  },
+  select: { id: true, workspaceId: true },
+}
+```
+
+Union those IDs with current runner IDs, then call `reconcile` for every item.
+Log one Worker failure without preventing other Workers from reconciling.
+Change `startAll()` to await `reconcileAll()`, set `isStarted` back to `false`
+if it rejects, and log the resulting runner count.
+
+- [ ] **Step 6: Publish committed local lifecycle changes**
+
+For local creation use `create`; for any existing Worker upsert use `update`;
+for deletion use `delete`. Invoke:
+
+```ts
+void workerCronBroadcast.publish(action, workspaceId, worker.id);
+```
+
+only after the corresponding PostgreSQL operation succeeds. Apply the exact
+persisted row locally through `applyWorkerStateUnlocked`, inside the same
+per-Worker queue.
+
+- [ ] **Step 7: Run focused Worker manager tests and verify GREEN**
+
+Run the Step 2 command. Expected: all Worker manager tests PASS.
+
+- [ ] **Step 8: Run Worker model regression tests**
+
+Run:
+
+```bash
+pnpm --dir src/server exec vitest run \
+  model/worker/broadcast.spec.ts \
+  model/worker/cronManager.spec.ts \
+  model/worker/index.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit manager reconciliation**
+
+```bash
+git add src/server/model/worker/cronManager.ts \
+  src/server/model/worker/cronManager.spec.ts
+git commit -m "fix(worker): reconcile cron runners across instances"
+```
+
+---
+
+### Task 3: Server lifecycle integration and final verification
+
+**Files:**
+- Modify: `src/server/main.ts`
+
+**Interfaces:**
+- Consumes `workerCronBroadcast`.
+- Starts Worker subscription with `workerCronManager.handleBroadcast`.
+- Uses `workerCronManager.reconcileAll` for Redis recovery.
+- Closes Worker transport during graceful shutdown.
+
+- [ ] **Step 1: Wire Worker broadcast before Worker runner startup**
+
+Import `workerCronBroadcast`. In `startServer()`, inside the
+`env.enableFunctionWorker` branch, use:
+
+```ts
+await workerCronBroadcast.start(
+  (event) => workerCronManager.handleBroadcast(event),
+  () => workerCronManager.reconcileAll()
+);
+if (isShuttingDown) {
+  return;
+}
+
+await workerCronManager.startAll();
+if (isShuttingDown) {
+  return;
+}
+```
+
+Await `startAll()` so HTTP listening does not race initial Worker
+reconciliation.
+
+- [ ] **Step 2: Close the Worker transport**
+
+During graceful shutdown, close both lifecycle transports:
+
+```ts
+await Promise.all([
+  monitorBroadcast.close(),
+  workerCronBroadcast.close(),
+]);
+```
+
+The Worker singleton is safe to close even when Worker functionality or Redis
+is disabled.
+
+- [ ] **Step 3: Run focused lifecycle tests**
+
+Run:
+
+```bash
+pnpm --dir src/server exec vitest run \
+  model/worker/broadcast.spec.ts \
+  model/worker/cronManager.spec.ts \
+  model/worker/index.spec.ts \
+  model/monitor/broadcast.spec.ts \
+  model/monitor/manager.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run CI-equivalent static verification**
+
+Run:
+
+```bash
+pnpm check:type
+pnpm build
+git diff --check
+```
+
+Expected: all commands exit successfully. If an unrelated pre-existing failure
+appears, record the exact command and failure separately from focused test
+results.
+
+- [ ] **Step 5: Commit lifecycle wiring**
+
+```bash
+git add src/server/main.ts
+git commit -m "feat(worker): wire cron lifecycle synchronization"
+```
+
+- [ ] **Step 6: Review final branch scope**
+
+Run:
+
+```bash
+git status --short
+git log --oneline master..HEAD
+git diff --stat master...HEAD
+```
+
+Confirm only the approved design, implementation plan, Worker lifecycle files,
+tests, and server wiring are present.

--- a/docs/superpowers/specs/2026-07-31-worker-cron-lifecycle-sync-design.md
+++ b/docs/superpowers/specs/2026-07-31-worker-cron-lifecycle-sync-design.md
@@ -1,0 +1,123 @@
+# Worker Cron Lifecycle Synchronization
+
+## Problem
+
+Each Tianji server instance owns an in-memory `WorkerCronManager` and its own
+`WorkerCronRunner` objects. Updating a worker currently replaces the runner only
+on the instance that handled the request. Other instances keep both the old cron
+expression and the old worker code captured by their existing runner.
+
+The distributed execution lock prevents concurrent executions of the same
+worker, but it does not invalidate stale runners. A stale instance can therefore
+continue scheduling at the old interval and execute old code whenever it
+acquires the lock.
+
+## Goals
+
+- Propagate worker lifecycle changes to every server instance when Redis is
+  configured.
+- Reload the complete worker record so cron configuration and executable code
+  change together.
+- Keep PostgreSQL as the authoritative state and Redis as an optional
+  invalidation signal.
+- Cover create, update, activation, deactivation, deletion, and code rollback.
+- Preserve the current single-instance and Redis-disabled behavior.
+
+## Non-goals
+
+- Durable event delivery or an outbox.
+- Refactoring the existing Monitor broadcast into a generic abstraction.
+- Changing worker execution locking or cron expression validation.
+- Modifying client translation files.
+
+## Architecture
+
+Add a Worker-specific `WorkerCronBroadcast`, modeled after
+`MonitorBroadcast`, with its own Redis channel:
+
+```text
+tianji:worker:cron:lifecycle
+```
+
+Events contain only lifecycle metadata:
+
+```ts
+{
+  action: 'create' | 'update' | 'start' | 'stop' | 'delete';
+  workspaceId: string;
+  workerId: string;
+  sourceInstanceId: string;
+}
+```
+
+Worker data and code are never sent through Redis. The receiving instance uses
+the identifiers to reload the current row from PostgreSQL.
+
+`WorkerCronManager` serializes lifecycle work per worker. Local mutations and
+remote reconciliation for the same worker share the same promise-tail queue,
+while different workers can reconcile concurrently.
+
+## Data Flow
+
+For a local mutation:
+
+1. Persist the worker mutation in PostgreSQL.
+2. Invalidate the local worker query cache.
+3. Publish a lifecycle event without making Redis availability a prerequisite
+   for the database mutation.
+4. Apply the persisted worker state to the local runner.
+
+For a remote event:
+
+1. Ignore events emitted by the current process.
+2. Serialize reconciliation by worker ID.
+3. Reload the worker from PostgreSQL using both workspace and worker IDs.
+4. Remove the local runner when the worker is missing, inactive, cron-disabled,
+   or has no cron expression.
+5. Otherwise stop the old runner, create a runner from the fresh worker and
+   workspace records, and start it.
+
+This replacement refreshes the cron expression, worker code, revision, and
+other captured worker fields as one unit.
+
+## Startup, Recovery, and Shutdown
+
+- Start the Worker broadcast subscription before starting Worker cron runners.
+- Run `reconcileAll()` at Worker manager startup instead of only adding active
+  database rows.
+- Run `reconcileAll()` after the Redis subscriber reconnects so missed changes
+  during a disconnection converge.
+- Close the Worker broadcast during graceful shutdown alongside the Monitor
+  broadcast.
+- When Redis is not configured, the broadcast creates no Redis clients and
+  Worker cron startup continues normally.
+
+## Failure Semantics
+
+Redis Pub/Sub remains best-effort, matching the existing Monitor design. A
+publish failure is logged but does not roll back a successful PostgreSQL
+mutation. Startup and reconnect reconciliation repair changes missed while an
+instance was disconnected, but a message lost while a subscriber remains
+connected can leave that instance stale until its next reconciliation or
+restart. Periodic reconciliation or durable delivery is intentionally outside
+this change.
+
+Malformed events are ignored. Handler, subscription, publishing, recovery, and
+cleanup failures are logged without crashing the server.
+
+## Tests
+
+Add focused tests proving:
+
+- A remote update reloads PostgreSQL state and replaces a runner containing an
+  old cron expression and old code.
+- A remote stop or delete removes and stops the stale local runner.
+- Full reconciliation adds missing active cron runners and removes stale or
+  disabled runners.
+- Same-worker lifecycle operations are serialized.
+- The Worker broadcast ignores self-originated and malformed events, recovers
+  after subscription, remains optional without Redis, and publishes the
+  expected event shape.
+
+Run the focused Worker and broadcast tests first, followed by server type
+checking and the repository build required by the contributor guide.

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -15,6 +15,7 @@ import { initClickHouse } from './clickhouse/index.js';
 import { flushAllBatchWriters } from './utils/batchWriter.js';
 import { logSystemInfo } from './utils/system.js';
 import { monitorBroadcast } from './model/monitor/broadcast.js';
+import { workerCronBroadcast } from './model/worker/broadcast.js';
 
 logSystemInfo();
 
@@ -59,7 +60,18 @@ async function startServer() {
   }
 
   if (env.enableFunctionWorker) {
-    workerCronManager.startAll();
+    await workerCronBroadcast.start(
+      (event) => workerCronManager.handleBroadcast(event),
+      () => workerCronManager.reconcileAll()
+    );
+    if (isShuttingDown) {
+      return;
+    }
+
+    await workerCronManager.startAll();
+    if (isShuttingDown) {
+      return;
+    }
   }
 
   httpServer.listen(port, () => {
@@ -83,7 +95,10 @@ async function gracefulShutdown(signal: string) {
   // Stop accepting new connections
   httpServer.close();
 
-  await monitorBroadcast.close();
+  await Promise.all([
+    monitorBroadcast.close(),
+    workerCronBroadcast.close(),
+  ]);
 
   // Flush all pending batch writes
   await flushAllBatchWriters();

--- a/src/server/model/worker/broadcast.spec.ts
+++ b/src/server/model/worker/broadcast.spec.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { logger } from '../../utils/logger.js';
+import {
+  WORKER_CRON_BROADCAST_CHANNEL,
+  WorkerCronBroadcast,
+  type WorkerCronBroadcastEvent,
+} from './broadcast.js';
+
+type Listener = (...args: any[]) => void;
+
+class FakeRedisClient {
+  private listeners = new Map<string, Listener[]>();
+
+  on = vi.fn((event: string, listener: Listener) => {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  });
+
+  subscribe = vi.fn(async () => 1);
+  publish = vi.fn(async () => 1);
+  quit = vi.fn(async () => 'OK');
+
+  emit(event: string, ...args: unknown[]) {
+    this.listeners.get(event)?.forEach((listener) => listener(...args));
+  }
+
+  emitRaw(raw: string, channel = WORKER_CRON_BROADCAST_CHANNEL) {
+    this.emit('message', channel, raw);
+  }
+
+  emitMessage(event: WorkerCronBroadcastEvent) {
+    this.emitRaw(JSON.stringify(event));
+  }
+}
+
+function createHarness(instanceId = 'instance-a') {
+  const publisher = new FakeRedisClient();
+  const subscriber = new FakeRedisClient();
+  const clients = [publisher, subscriber];
+  const createClient = vi.fn(() => clients.shift()!);
+  const broadcast = new WorkerCronBroadcast(
+    'redis://localhost:6379',
+    instanceId,
+    createClient
+  );
+
+  return { broadcast, publisher, subscriber, createClient };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('WorkerCronBroadcast', () => {
+  test('does not construct redis clients without a redis url', async () => {
+    const createClient = vi.fn();
+    const broadcast = new WorkerCronBroadcast(
+      undefined,
+      'instance-a',
+      createClient
+    );
+
+    await expect(
+      broadcast.start(vi.fn(), vi.fn(), 50)
+    ).resolves.toBe(true);
+
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  test('successful initial subscription does not invoke recovery', async () => {
+    const { broadcast, subscriber } = createHarness();
+    const recovery = vi.fn();
+
+    await expect(
+      broadcast.start(vi.fn(), recovery, 50)
+    ).resolves.toBe(true);
+
+    expect(subscriber.subscribe).toHaveBeenCalledWith(
+      WORKER_CRON_BROADCAST_CHANNEL
+    );
+    expect(recovery).not.toHaveBeenCalled();
+  });
+
+  test('concurrent starts share the initial subscription result', async () => {
+    const { broadcast, subscriber, createClient } = createHarness();
+    const subscription = deferred<number>();
+    subscriber.subscribe.mockReturnValue(subscription.promise);
+
+    const firstStart = broadcast.start(vi.fn(), vi.fn(), 50);
+    const secondStart = broadcast.start(vi.fn(), vi.fn(), 50);
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(subscriber.subscribe).toHaveBeenCalledOnce();
+
+    subscription.resolve(1);
+
+    await expect(Promise.all([firstStart, secondStart])).resolves.toEqual([
+      true,
+      true,
+    ]);
+  });
+
+  test('unresolved initial subscription times out', async () => {
+    vi.useFakeTimers();
+    const { broadcast, subscriber } = createHarness();
+    subscriber.subscribe.mockReturnValue(new Promise(() => undefined));
+
+    const started = broadcast.start(vi.fn(), vi.fn(), 50);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(started).resolves.toBe(false);
+  });
+
+  test('reconnect resubscribes and invokes recovery', async () => {
+    const { broadcast, subscriber } = createHarness();
+    const recovery = vi.fn(async () => undefined);
+    await broadcast.start(vi.fn(), recovery, 50);
+
+    subscriber.emit('close');
+    subscriber.emit('ready');
+
+    await vi.waitFor(() => {
+      expect(subscriber.subscribe).toHaveBeenCalledTimes(2);
+      expect(recovery).toHaveBeenCalledOnce();
+    });
+  });
+
+  test('delivers valid worker messages from another instance', async () => {
+    const { broadcast, subscriber } = createHarness();
+    const handler = vi.fn();
+    await broadcast.start(handler, vi.fn(), 50);
+
+    subscriber.emitMessage({
+      action: 'update',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-b',
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      action: 'update',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-b',
+    });
+  });
+
+  test('ignores self-originated, malformed, and other-channel messages', async () => {
+    const { broadcast, subscriber } = createHarness();
+    const handler = vi.fn();
+    await broadcast.start(handler, vi.fn(), 50);
+
+    subscriber.emitMessage({
+      action: 'update',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-a',
+    });
+    subscriber.emitRaw('{');
+    subscriber.emitRaw(JSON.stringify({ action: 'update' }));
+    subscriber.emitRaw(
+      JSON.stringify({
+        action: 'update',
+        workspaceId: 'workspace-a',
+        workerId: 'worker-a',
+        sourceInstanceId: 'instance-b',
+      }),
+      'another-channel'
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('publishes the worker event with the current instance id', async () => {
+    const { broadcast, publisher } = createHarness();
+    await broadcast.start(vi.fn(), vi.fn(), 50);
+
+    await broadcast.publish('update', 'workspace-a', 'worker-a');
+
+    expect(publisher.publish).toHaveBeenCalledWith(
+      WORKER_CRON_BROADCAST_CHANNEL,
+      JSON.stringify({
+        action: 'update',
+        workspaceId: 'workspace-a',
+        workerId: 'worker-a',
+        sourceInstanceId: 'instance-a',
+      })
+    );
+  });
+
+  test('close quits both clients and disables later activity', async () => {
+    const { broadcast, publisher, subscriber } = createHarness();
+    const handler = vi.fn();
+    const recovery = vi.fn();
+    await broadcast.start(handler, recovery, 50);
+
+    await broadcast.close();
+    subscriber.emit('ready');
+    subscriber.emitMessage({
+      action: 'delete',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-b',
+    });
+    await broadcast.publish('delete', 'workspace-a', 'worker-a');
+
+    expect(publisher.quit).toHaveBeenCalledOnce();
+    expect(subscriber.quit).toHaveBeenCalledOnce();
+    expect(subscriber.subscribe).toHaveBeenCalledOnce();
+    expect(publisher.publish).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(recovery).not.toHaveBeenCalled();
+  });
+
+  test('absorbs handler, publish, recovery, and cleanup failures', async () => {
+    vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    const { broadcast, publisher, subscriber } = createHarness();
+    const handler = vi.fn(async () => {
+      throw new Error('handler failed');
+    });
+    const recovery = vi.fn(async () => {
+      throw new Error('recovery failed');
+    });
+    publisher.publish.mockRejectedValue(new Error('publish failed'));
+    publisher.quit.mockRejectedValue(new Error('publisher quit failed'));
+    subscriber.quit.mockRejectedValue(new Error('subscriber quit failed'));
+    await broadcast.start(handler, recovery, 50);
+
+    subscriber.emitMessage({
+      action: 'update',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+      sourceInstanceId: 'instance-b',
+    });
+    subscriber.emit('close');
+    subscriber.emit('ready');
+
+    await expect(
+      broadcast.publish('update', 'workspace-a', 'worker-a')
+    ).resolves.toBeUndefined();
+    await expect(broadcast.close()).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledOnce();
+      expect(recovery).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/server/model/worker/broadcast.ts
+++ b/src/server/model/worker/broadcast.ts
@@ -1,0 +1,331 @@
+import { Redis } from 'ioredis';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+import { env } from '../../utils/env.js';
+import { logger } from '../../utils/logger.js';
+
+export const WORKER_CRON_BROADCAST_CHANNEL = 'tianji:worker:cron:lifecycle';
+
+export type WorkerCronBroadcastAction =
+  | 'create'
+  | 'update'
+  | 'start'
+  | 'stop'
+  | 'delete';
+
+export interface WorkerCronBroadcastEvent {
+  action: WorkerCronBroadcastAction;
+  workspaceId: string;
+  workerId: string;
+  sourceInstanceId: string;
+}
+
+type WorkerCronBroadcastHandler = (
+  event: WorkerCronBroadcastEvent
+) => void | Promise<void>;
+
+interface RedisClient {
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  subscribe(channel: string): Promise<unknown>;
+  publish(channel: string, message: string): Promise<unknown>;
+  quit(): Promise<unknown>;
+}
+
+type RedisClientFactory = (url: string) => RedisClient;
+
+const workerCronBroadcastEventSchema = z.object({
+  action: z.enum(['create', 'update', 'start', 'stop', 'delete']),
+  workspaceId: z.string(),
+  workerId: z.string(),
+  sourceInstanceId: z.string(),
+});
+
+export class WorkerCronBroadcast {
+  private publisher?: RedisClient;
+  private subscriber?: RedisClient;
+  private starting?: Promise<boolean>;
+  private closing?: Promise<void>;
+  private subscribed = false;
+  private subscribing?: Promise<void>;
+  private closed = false;
+  private startupWaitFinished = false;
+  private hasSubscribed = false;
+  private retryTimer?: ReturnType<typeof setTimeout>;
+  private recover?: () => void | Promise<void>;
+  private resolveFirstReady?: () => void;
+  private connectionVersion = 0;
+
+  constructor(
+    private readonly redisUrl: string | undefined,
+    private readonly instanceId: string,
+    private readonly createClient: RedisClientFactory
+  ) {}
+
+  async start(
+    handler: WorkerCronBroadcastHandler,
+    recover: () => void | Promise<void>,
+    readinessTimeoutMs = 5_000
+  ): Promise<boolean> {
+    if (this.closed) {
+      return false;
+    }
+
+    if (!this.redisUrl) {
+      return true;
+    }
+
+    if (this.starting) {
+      return this.starting;
+    }
+
+    if (this.publisher || this.subscriber) {
+      return this.subscribed;
+    }
+
+    const starting = this.initialize(
+      this.redisUrl,
+      handler,
+      recover,
+      readinessTimeoutMs
+    );
+    this.starting = starting;
+    try {
+      return await starting;
+    } finally {
+      if (this.starting === starting) {
+        this.starting = undefined;
+      }
+    }
+  }
+
+  private async initialize(
+    redisUrl: string,
+    handler: WorkerCronBroadcastHandler,
+    recover: () => void | Promise<void>,
+    readinessTimeoutMs: number
+  ): Promise<boolean> {
+    try {
+      this.publisher = this.createClient(redisUrl);
+      this.subscriber = this.createClient(redisUrl);
+      this.recover = recover;
+
+      this.publisher.on('error', (err) => {
+        logger.error('[WorkerCronBroadcast] Redis publisher error:', err);
+      });
+      this.subscriber.on('error', (err) => {
+        logger.error('[WorkerCronBroadcast] Redis subscriber error:', err);
+      });
+      this.subscriber.on('ready', () => {
+        this.ensureSubscribed();
+      });
+      this.subscriber.on('close', () => {
+        this.markDisconnected();
+      });
+      this.subscriber.on('end', () => {
+        this.markDisconnected();
+      });
+      this.subscriber.on('message', (channel, raw) => {
+        if (this.closed || channel !== WORKER_CRON_BROADCAST_CHANNEL) {
+          return;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(String(raw));
+        } catch {
+          return;
+        }
+
+        const event = workerCronBroadcastEventSchema.safeParse(parsed);
+        if (
+          !event.success ||
+          event.data.sourceInstanceId === this.instanceId
+        ) {
+          return;
+        }
+
+        try {
+          void Promise.resolve(handler(event.data)).catch((err) => {
+            logger.error('[WorkerCronBroadcast] Handler error:', err);
+          });
+        } catch (err) {
+          logger.error('[WorkerCronBroadcast] Handler error:', err);
+        }
+      });
+
+      const firstReady = new Promise<void>((resolve) => {
+        this.resolveFirstReady = resolve;
+      });
+      this.ensureSubscribed();
+
+      let readinessTimer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = new Promise<boolean>((resolve) => {
+        readinessTimer = setTimeout(() => resolve(false), readinessTimeoutMs);
+        readinessTimer.unref?.();
+      });
+      const ready = firstReady.then(() => true);
+      const subscribed = await Promise.race([ready, timedOut]);
+      if (readinessTimer) {
+        clearTimeout(readinessTimer);
+      }
+      this.startupWaitFinished = true;
+
+      return subscribed;
+    } catch (err) {
+      logger.error('[WorkerCronBroadcast] Failed to initialize Redis:', err);
+      return false;
+    }
+  }
+
+  private markDisconnected(): void {
+    this.subscribed = false;
+    this.subscribing = undefined;
+    this.connectionVersion += 1;
+  }
+
+  private ensureSubscribed(): void {
+    if (
+      this.closed ||
+      !this.subscriber ||
+      this.subscribed ||
+      this.subscribing
+    ) {
+      return;
+    }
+
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = undefined;
+    }
+
+    const connectionVersion = this.connectionVersion;
+    const attempt = this.subscribe(connectionVersion);
+    this.subscribing = attempt;
+    void attempt.finally(() => {
+      if (this.subscribing === attempt) {
+        this.subscribing = undefined;
+      }
+
+      if (!this.closed && !this.subscribed && !this.subscribing) {
+        this.scheduleRetry();
+      }
+    });
+  }
+
+  private async subscribe(connectionVersion: number): Promise<void> {
+    try {
+      await this.subscriber?.subscribe(WORKER_CRON_BROADCAST_CHANNEL);
+      if (
+        this.closed ||
+        !this.subscriber ||
+        connectionVersion !== this.connectionVersion
+      ) {
+        return;
+      }
+
+      const shouldRecover = this.startupWaitFinished || this.hasSubscribed;
+      this.subscribed = true;
+      this.hasSubscribed = true;
+      this.resolveFirstReady?.();
+      this.resolveFirstReady = undefined;
+
+      if (shouldRecover) {
+        this.runRecovery();
+      }
+    } catch (err) {
+      logger.error('[WorkerCronBroadcast] Redis subscribe error:', err);
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryTimer) {
+      return;
+    }
+
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      this.ensureSubscribed();
+    }, 1_000);
+    this.retryTimer.unref?.();
+  }
+
+  private runRecovery(): void {
+    try {
+      void Promise.resolve(this.recover?.()).catch((err) => {
+        logger.error('[WorkerCronBroadcast] Recovery error:', err);
+      });
+    } catch (err) {
+      logger.error('[WorkerCronBroadcast] Recovery error:', err);
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closing) {
+      return this.closing;
+    }
+
+    this.closed = true;
+    this.subscribed = false;
+    this.connectionVersion += 1;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = undefined;
+    }
+
+    const publisher = this.publisher;
+    const subscriber = this.subscriber;
+    this.publisher = undefined;
+    this.subscriber = undefined;
+
+    this.closing = this.closeClients(publisher, subscriber);
+    return this.closing;
+  }
+
+  private async closeClients(
+    publisher: RedisClient | undefined,
+    subscriber: RedisClient | undefined
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      [publisher, subscriber]
+        .filter((client): client is RedisClient => Boolean(client))
+        .map((client) => Promise.resolve().then(() => client.quit()))
+    );
+    results.forEach((result) => {
+      if (result.status === 'rejected') {
+        logger.error('[WorkerCronBroadcast] Redis cleanup error:', result.reason);
+      }
+    });
+  }
+
+  async publish(
+    action: WorkerCronBroadcastAction,
+    workspaceId: string,
+    workerId: string
+  ): Promise<void> {
+    if (this.closed || !this.publisher) {
+      return;
+    }
+
+    const event: WorkerCronBroadcastEvent = {
+      action,
+      workspaceId,
+      workerId,
+      sourceInstanceId: this.instanceId,
+    };
+
+    try {
+      await this.publisher.publish(
+        WORKER_CRON_BROADCAST_CHANNEL,
+        JSON.stringify(event)
+      );
+    } catch (err) {
+      logger.error('[WorkerCronBroadcast] Redis publish error:', err);
+    }
+  }
+}
+
+export const workerCronBroadcast = new WorkerCronBroadcast(
+  env.cache.redisUrl,
+  nanoid(),
+  (url) => new Redis(url)
+);

--- a/src/server/model/worker/cronManager.spec.ts
+++ b/src/server/model/worker/cronManager.spec.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const runnerInstances: Array<{
+    workspace: any;
+    worker: any;
+    startCron: ReturnType<typeof vi.fn>;
+    stopCron: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  class WorkerCronRunner {
+    startCron = vi.fn(async () => undefined);
+    stopCron = vi.fn(async () => undefined);
+
+    constructor(
+      public workspace: any,
+      public worker: any
+    ) {
+      runnerInstances.push(this);
+    }
+  }
+
+  const prisma = {
+    functionWorker: {
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    functionWorkerRevision: {
+      create: vi.fn(),
+    },
+    workspace: {
+      findUniqueOrThrow: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+
+  return {
+    runnerInstances,
+    WorkerCronRunner,
+    prisma,
+    delWorkerCache: vi.fn(),
+    workerCronBroadcast: {
+      publish: vi.fn(async () => undefined),
+    },
+  };
+});
+
+vi.mock('../_client.js', () => ({ prisma: mocks.prisma }));
+vi.mock('./cronRunner.js', () => ({
+  WorkerCronRunner: mocks.WorkerCronRunner,
+}));
+vi.mock('./index.js', () => ({
+  delWorkerCache: mocks.delWorkerCache,
+}));
+vi.mock('./broadcast.js', () => ({
+  workerCronBroadcast: mocks.workerCronBroadcast,
+}));
+
+import { WorkerCronManager } from './cronManager.js';
+import type {
+  WorkerCronBroadcastAction,
+  WorkerCronBroadcastEvent,
+} from './broadcast.js';
+
+const workspace = {
+  id: 'workspace-a',
+  name: 'Workspace A',
+  settings: {},
+};
+
+const activeWorker = {
+  id: 'worker-a',
+  workspaceId: 'workspace-a',
+  name: 'Worker A',
+  description: null,
+  code: 'return "current";',
+  revision: 1,
+  active: true,
+  enableCron: true,
+  cronExpression: '*/10 * * * *',
+  visibility: 'Public',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const oldWorker = {
+  ...activeWorker,
+  code: 'return "old";',
+  cronExpression: '*/5 * * * *',
+  revision: 1,
+};
+
+const updatedWorker = {
+  ...activeWorker,
+  code: 'return "new";',
+  cronExpression: '*/30 * * * *',
+  revision: 2,
+};
+
+const upsertInput = {
+  workspaceId: 'workspace-a',
+  name: 'Worker A',
+  description: undefined,
+  code: updatedWorker.code,
+  active: true,
+  enableCron: true,
+  cronExpression: updatedWorker.cronExpression,
+};
+
+function remoteEvent(
+  action: WorkerCronBroadcastAction,
+  workerId = 'worker-a',
+  workspaceId = 'workspace-a'
+): WorkerCronBroadcastEvent {
+  return {
+    action,
+    workspaceId,
+    workerId,
+    sourceInstanceId: 'instance-b',
+  };
+}
+
+function seedRunner(manager: WorkerCronManager, worker = oldWorker) {
+  const runner = new mocks.WorkerCronRunner(workspace, worker);
+  (manager as any).workerRunners[worker.id] = runner;
+  return runner;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.runnerInstances.length = 0;
+  mocks.prisma.workspace.findUniqueOrThrow.mockResolvedValue(workspace);
+  mocks.prisma.functionWorkerRevision.create.mockResolvedValue({});
+  mocks.prisma.$transaction.mockImplementation(async (operation: any) =>
+    operation(mocks.prisma)
+  );
+  mocks.workerCronBroadcast.publish.mockResolvedValue(undefined);
+});
+
+describe('WorkerCronManager lifecycle synchronization', () => {
+  test('remote update replaces stale cron expression and worker code', async () => {
+    const manager = new WorkerCronManager();
+    const oldRunner = seedRunner(manager);
+    mocks.prisma.functionWorker.findUnique.mockResolvedValue(updatedWorker);
+
+    await manager.handleBroadcast(remoteEvent('update'));
+
+    expect(mocks.prisma.functionWorker.findUnique).toHaveBeenCalledWith({
+      where: {
+        id: 'worker-a',
+        workspaceId: 'workspace-a',
+      },
+    });
+    expect(oldRunner.stopCron).toHaveBeenCalledOnce();
+    expect(mocks.runnerInstances).toHaveLength(2);
+    expect(mocks.runnerInstances[1].worker.cronExpression).toBe(
+      '*/30 * * * *'
+    );
+    expect(mocks.runnerInstances[1].worker.code).toBe('return "new";');
+    expect(mocks.runnerInstances[1].startCron).toHaveBeenCalledOnce();
+    expect(manager.getRunner('worker-a')).toBe(mocks.runnerInstances[1]);
+  });
+
+  test.each([
+    ['missing', null],
+    ['inactive', { ...updatedWorker, active: false }],
+    ['cron-disabled', { ...updatedWorker, enableCron: false }],
+    ['expression-missing', { ...updatedWorker, cronExpression: null }],
+  ])('remote event removes a runner for %s state', async (_name, state) => {
+    const manager = new WorkerCronManager();
+    const oldRunner = seedRunner(manager);
+    mocks.prisma.functionWorker.findUnique.mockResolvedValue(state);
+
+    await manager.handleBroadcast(remoteEvent('delete'));
+
+    expect(oldRunner.stopCron).toHaveBeenCalledOnce();
+    expect(manager.getRunner('worker-a')).toBeUndefined();
+    expect(mocks.runnerInstances).toHaveLength(1);
+  });
+
+  test('serializes overlapping reconciliation for one worker', async () => {
+    const manager = new WorkerCronManager();
+    const firstWorkspaceLookup = deferred<typeof workspace>();
+    mocks.prisma.functionWorker.findUnique.mockResolvedValue(updatedWorker);
+    mocks.prisma.workspace.findUniqueOrThrow
+      .mockReturnValueOnce(firstWorkspaceLookup.promise)
+      .mockResolvedValueOnce(workspace);
+
+    const first = manager.reconcile('workspace-a', 'worker-a');
+    await vi.waitFor(() => {
+      expect(mocks.prisma.workspace.findUniqueOrThrow).toHaveBeenCalledOnce();
+    });
+    const second = manager.reconcile('workspace-a', 'worker-a');
+
+    expect(mocks.prisma.functionWorker.findUnique).toHaveBeenCalledOnce();
+    firstWorkspaceLookup.resolve(workspace);
+    await first;
+    await second;
+
+    expect(mocks.prisma.functionWorker.findUnique).toHaveBeenCalledTimes(2);
+    expect(mocks.runnerInstances).toHaveLength(2);
+    expect(mocks.runnerInstances[0].stopCron).toHaveBeenCalledOnce();
+    expect(manager.getRunner('worker-a')).toBe(mocks.runnerInstances[1]);
+  });
+
+  test('does not globally serialize different workers', async () => {
+    const manager = new WorkerCronManager();
+    const workspaceALookup = deferred<typeof workspace>();
+    const workerB = {
+      ...updatedWorker,
+      id: 'worker-b',
+      workspaceId: 'workspace-b',
+    };
+    mocks.prisma.functionWorker.findUnique.mockImplementation(
+      ({ where }: any) =>
+        Promise.resolve(where.id === 'worker-a' ? updatedWorker : workerB)
+    );
+    mocks.prisma.workspace.findUniqueOrThrow.mockImplementation(
+      ({ where }: any) =>
+        where.id === 'workspace-a'
+          ? workspaceALookup.promise
+          : Promise.resolve({ ...workspace, id: 'workspace-b' })
+    );
+
+    const first = manager.reconcile('workspace-a', 'worker-a');
+    const second = manager.reconcile('workspace-b', 'worker-b');
+
+    await second;
+    expect(manager.getRunner('worker-b')).toBeDefined();
+    expect(manager.getRunner('worker-a')).toBeUndefined();
+
+    workspaceALookup.resolve(workspace);
+    await first;
+  });
+
+  test('continues a worker queue after a rejected operation', async () => {
+    const manager = new WorkerCronManager();
+    mocks.prisma.functionWorker.findUnique
+      .mockRejectedValueOnce(new Error('lookup failed'))
+      .mockResolvedValueOnce(updatedWorker);
+
+    await expect(
+      manager.reconcile('workspace-a', 'worker-a')
+    ).rejects.toThrow('lookup failed');
+    await expect(
+      manager.reconcile('workspace-a', 'worker-a')
+    ).resolves.toBeUndefined();
+
+    expect(manager.getRunner('worker-a')).toBeDefined();
+  });
+
+  test('failed workspace lookup preserves the old runner', async () => {
+    const manager = new WorkerCronManager();
+    const oldRunner = seedRunner(manager);
+    mocks.prisma.functionWorker.findUnique.mockResolvedValue(updatedWorker);
+    mocks.prisma.workspace.findUniqueOrThrow.mockRejectedValue(
+      new Error('workspace unavailable')
+    );
+
+    await expect(
+      manager.reconcile('workspace-a', 'worker-a')
+    ).rejects.toThrow('workspace unavailable');
+
+    expect(oldRunner.stopCron).not.toHaveBeenCalled();
+    expect(manager.getRunner('worker-a')).toBe(oldRunner);
+  });
+
+  test('reconcileAll starts missing runners and removes stale runners', async () => {
+    const manager = new WorkerCronManager();
+    const staleRunner = seedRunner(manager);
+    const workerB = {
+      ...updatedWorker,
+      id: 'worker-b',
+      workspaceId: 'workspace-b',
+    };
+    mocks.prisma.functionWorker.findMany.mockResolvedValue([
+      { id: 'worker-b', workspaceId: 'workspace-b' },
+    ]);
+    mocks.prisma.functionWorker.findUnique.mockImplementation(
+      ({ where }: any) =>
+        Promise.resolve(where.id === 'worker-b' ? workerB : null)
+    );
+    mocks.prisma.workspace.findUniqueOrThrow.mockResolvedValue({
+      ...workspace,
+      id: 'workspace-b',
+    });
+
+    await manager.reconcileAll();
+
+    expect(staleRunner.stopCron).toHaveBeenCalledOnce();
+    expect(manager.getRunner('worker-a')).toBeUndefined();
+    expect(manager.getRunner('worker-b')).toBeDefined();
+    expect(manager.getRunner('worker-b')?.worker.code).toBe(
+      'return "new";'
+    );
+  });
+
+  test('successful update publishes after persistence and applies the returned row', async () => {
+    const manager = new WorkerCronManager();
+    seedRunner(manager);
+    mocks.prisma.functionWorker.findUnique.mockResolvedValue(oldWorker);
+    mocks.prisma.functionWorker.update.mockResolvedValue(updatedWorker);
+
+    const result = await manager.upsert({
+      ...upsertInput,
+      id: 'worker-a',
+    });
+
+    expect(result).toBe(updatedWorker);
+    expect(mocks.workerCronBroadcast.publish).toHaveBeenCalledWith(
+      'update',
+      'workspace-a',
+      'worker-a'
+    );
+    expect(manager.getRunner('worker-a')?.worker.code).toBe(
+      'return "new";'
+    );
+  });
+
+  test('successful create publishes the generated worker id', async () => {
+    const manager = new WorkerCronManager();
+    mocks.prisma.functionWorker.create.mockResolvedValue(updatedWorker);
+
+    await manager.upsert(upsertInput);
+
+    expect(mocks.workerCronBroadcast.publish).toHaveBeenCalledWith(
+      'create',
+      'workspace-a',
+      'worker-a'
+    );
+    expect(manager.getRunner('worker-a')?.worker.cronExpression).toBe(
+      '*/30 * * * *'
+    );
+  });
+
+  test('delete publishes only after successful persistence', async () => {
+    const manager = new WorkerCronManager();
+    const oldRunner = seedRunner(manager);
+    mocks.prisma.functionWorker.delete.mockResolvedValue(oldWorker);
+
+    await manager.delete('workspace-a', 'worker-a');
+
+    expect(oldRunner.stopCron).toHaveBeenCalledOnce();
+    expect(manager.getRunner('worker-a')).toBeUndefined();
+    expect(mocks.workerCronBroadcast.publish).toHaveBeenCalledWith(
+      'delete',
+      'workspace-a',
+      'worker-a'
+    );
+  });
+
+  test('failed deletion preserves the runner and is not broadcast', async () => {
+    const manager = new WorkerCronManager();
+    const oldRunner = seedRunner(manager);
+    mocks.prisma.functionWorker.delete.mockRejectedValue(
+      new Error('delete failed')
+    );
+
+    await expect(
+      manager.delete('workspace-a', 'worker-a')
+    ).rejects.toThrow('delete failed');
+
+    expect(oldRunner.stopCron).not.toHaveBeenCalled();
+    expect(manager.getRunner('worker-a')).toBe(oldRunner);
+    expect(mocks.workerCronBroadcast.publish).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/model/worker/cronManager.ts
+++ b/src/server/model/worker/cronManager.ts
@@ -3,6 +3,10 @@ import { prisma } from '../_client.js';
 import { WorkerCronRunner } from './cronRunner.js';
 import { logger } from '../../utils/logger.js';
 import { delWorkerCache } from './index.js';
+import {
+  workerCronBroadcast,
+  type WorkerCronBroadcastEvent,
+} from './broadcast.js';
 
 export type WorkerCronUpsertData = Pick<
   FunctionWorker,
@@ -15,115 +19,130 @@ export type WorkerCronUpsertData = Pick<
 
 export class WorkerCronManager {
   private workerRunners: Record<string, WorkerCronRunner> = {};
+  private lifecycleTails = new Map<string, Promise<void>>();
   private isStarted = false;
+
+  private runLifecycle<T>(
+    workerId: string,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const previous = this.lifecycleTails.get(workerId) ?? Promise.resolve();
+    const result = previous.catch(() => undefined).then(operation);
+    const tail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    this.lifecycleTails.set(workerId, tail);
+
+    return result.finally(() => {
+      if (this.lifecycleTails.get(workerId) === tail) {
+        this.lifecycleTails.delete(workerId);
+      }
+    });
+  }
 
   /**
    * Create or update worker cron job
    */
   async upsert(data: WorkerCronUpsertData): Promise<FunctionWorker> {
-    let worker: FunctionWorker;
     const { id, workspaceId, ...others } = data;
 
     if (id) {
-      const existingWorker = await prisma.functionWorker.findUnique({
-        where: {
-          id,
-          workspaceId,
-        },
-      });
-
-      if (!existingWorker) {
-        throw new Error('Worker not found');
-      }
-
-      const shouldCreateRevision =
-        others.code !== undefined && others.code !== existingWorker.code;
-
-      const updateResult = await prisma.$transaction(async (tx) => {
-        const nextRevision = shouldCreateRevision
-          ? existingWorker.revision + 1
-          : existingWorker.revision;
-
-        const updatedWorker = await tx.functionWorker.update({
+      return this.runLifecycle(id, async () => {
+        const existingWorker = await prisma.functionWorker.findUnique({
           where: {
             id,
             workspaceId,
           },
-          data: {
-            ...others,
-            revision: nextRevision,
-          },
         });
 
-        delWorkerCache(id, workspaceId);
+        if (!existingWorker) {
+          throw new Error('Worker not found');
+        }
 
-        if (shouldCreateRevision) {
-          await tx.functionWorkerRevision.create({
+        const shouldCreateRevision =
+          others.code !== undefined && others.code !== existingWorker.code;
+
+        const worker = await prisma.$transaction(async (tx) => {
+          const nextRevision = shouldCreateRevision
+            ? existingWorker.revision + 1
+            : existingWorker.revision;
+
+          const updatedWorker = await tx.functionWorker.update({
+            where: {
+              id,
+              workspaceId,
+            },
             data: {
-              workerId: updatedWorker.id,
-              revision: updatedWorker.revision,
-              code: updatedWorker.code,
+              ...others,
+              revision: nextRevision,
             },
           });
-        }
-        return updatedWorker;
-      });
 
-      worker = updateResult;
-    } else {
-      worker = await prisma.$transaction(async (tx) => {
-        const createdWorker = await tx.functionWorker.create({
-          data: {
-            ...others,
-            revision: 1,
-            workspaceId,
-          },
+          delWorkerCache(id, workspaceId);
+
+          if (shouldCreateRevision) {
+            await tx.functionWorkerRevision.create({
+              data: {
+                workerId: updatedWorker.id,
+                revision: updatedWorker.revision,
+                code: updatedWorker.code,
+              },
+            });
+          }
+          return updatedWorker;
         });
 
-        await tx.functionWorkerRevision.create({
-          data: {
-            workerId: createdWorker.id,
-            revision: createdWorker.revision,
-            code: createdWorker.code,
-          },
-        });
+        void workerCronBroadcast.publish('update', workspaceId, worker.id);
+        await this.applyWorkerStateUnlocked(worker);
 
-        return createdWorker;
+        return worker;
       });
     }
 
-    // Stop and remove old runner if exists
-    if (this.workerRunners[worker.id]) {
-      await this.workerRunners[worker.id].stopCron();
-      delete this.workerRunners[worker.id];
-    }
+    const worker = await prisma.$transaction(async (tx) => {
+      const createdWorker = await tx.functionWorker.create({
+        data: {
+          ...others,
+          revision: 1,
+          workspaceId,
+        },
+      });
 
-    // Create new runner if cron is enabled
-    if (worker.active && worker.enableCron && worker.cronExpression) {
-      const runner = await this.createRunner(worker);
-      await runner.startCron();
-    }
+      await tx.functionWorkerRevision.create({
+        data: {
+          workerId: createdWorker.id,
+          revision: createdWorker.revision,
+          code: createdWorker.code,
+        },
+      });
 
-    return worker;
+      return createdWorker;
+    });
+
+    return this.runLifecycle(worker.id, async () => {
+      void workerCronBroadcast.publish('create', workspaceId, worker.id);
+      await this.applyWorkerStateUnlocked(worker);
+
+      return worker;
+    });
   }
 
   async delete(workspaceId: string, workerId: string) {
-    const runner = this.getRunner(workerId);
-    if (runner) {
-      await runner.stopCron();
-      delete this.workerRunners[workerId];
-    }
+    return this.runLifecycle(workerId, async () => {
+      const worker = await prisma.functionWorker.delete({
+        where: {
+          workspaceId,
+          id: workerId,
+        },
+      });
 
-    const res = await prisma.functionWorker.delete({
-      where: {
-        workspaceId,
-        id: workerId,
-      },
+      delWorkerCache(workerId, workspaceId);
+      await this.removeRunner(workerId);
+      void workerCronBroadcast.publish('delete', workspaceId, workerId);
+
+      return worker;
     });
-
-    delWorkerCache(workerId, workspaceId);
-
-    return res;
   }
 
   /**
@@ -137,7 +156,62 @@ export class WorkerCronManager {
 
     this.isStarted = true;
 
-    const workers = await prisma.functionWorker.findMany({
+    try {
+      await this.reconcileAll();
+      logger.info(
+        `Started ${Object.keys(this.workerRunners).length} worker cron jobs.`
+      );
+    } catch (err) {
+      this.isStarted = false;
+      throw err;
+    }
+  }
+
+  getRunner(workerId: string): WorkerCronRunner | undefined {
+    return this.workerRunners[workerId];
+  }
+
+  private async removeRunner(workerId: string): Promise<void> {
+    const runner = this.getRunner(workerId);
+    if (!runner) {
+      return;
+    }
+
+    await runner.stopCron();
+    delete this.workerRunners[workerId];
+  }
+
+  async reconcile(workspaceId: string, workerId: string): Promise<void> {
+    return this.runLifecycle(workerId, () =>
+      this.reconcileUnlocked(workspaceId, workerId)
+    );
+  }
+
+  private async reconcileUnlocked(
+    workspaceId: string,
+    workerId: string
+  ): Promise<void> {
+    const worker = await prisma.functionWorker.findUnique({
+      where: {
+        id: workerId,
+        workspaceId,
+      },
+    });
+
+    if (
+      !worker?.active ||
+      !worker.enableCron ||
+      !worker.cronExpression
+    ) {
+      await this.removeRunner(workerId);
+      return;
+    }
+
+    await this.applyWorkerStateUnlocked(worker);
+  }
+
+  async reconcileAll(): Promise<void> {
+    const activeWorkers = await prisma.functionWorker.findMany({
       where: {
         active: true,
         enableCron: true,
@@ -145,25 +219,46 @@ export class WorkerCronManager {
           not: null,
         },
       },
+      select: {
+        id: true,
+        workspaceId: true,
+      },
+    });
+    const workers = new Map<string, string>();
+
+    Object.values(this.workerRunners).forEach((runner) => {
+      workers.set(runner.worker.id, runner.worker.workspaceId);
+    });
+    activeWorkers.forEach((worker) => {
+      workers.set(worker.id, worker.workspaceId);
     });
 
-    Promise.all(
-      workers.map(async (worker) => {
+    await Promise.all(
+      Array.from(workers, async ([workerId, workspaceId]) => {
         try {
-          const runner = await this.createRunner(worker);
-          this.workerRunners[worker.id] = runner;
-          await runner.startCron();
+          await this.reconcile(workspaceId, workerId);
         } catch (err) {
-          logger.error('Start worker cron error:', String(err));
+          logger.error('Reconcile worker cron error:', String(err));
         }
       })
-    ).then(() => {
-      logger.info(`Started ${workers.length} worker cron jobs.`);
-    });
+    );
   }
 
-  getRunner(workerId: string): WorkerCronRunner | undefined {
-    return this.workerRunners[workerId];
+  async handleBroadcast(event: WorkerCronBroadcastEvent): Promise<void> {
+    await this.reconcile(event.workspaceId, event.workerId);
+  }
+
+  private async applyWorkerStateUnlocked(
+    worker: FunctionWorker
+  ): Promise<WorkerCronRunner | undefined> {
+    if (!worker.active || !worker.enableCron || !worker.cronExpression) {
+      await this.removeRunner(worker.id);
+      return undefined;
+    }
+
+    const runner = await this.createRunner(worker);
+    await runner.startCron();
+    return runner;
   }
 
   /**
@@ -181,16 +276,13 @@ export class WorkerCronManager {
    * Create runner
    */
   async createRunner(worker: FunctionWorker) {
-    if (this.workerRunners[worker.id]) {
-      await this.workerRunners[worker.id].stopCron();
-    }
-
     const workspace = await prisma.workspace.findUniqueOrThrow({
       where: {
         id: worker.workspaceId,
       },
     });
 
+    await this.removeRunner(worker.id);
     const runner = (this.workerRunners[worker.id] = new WorkerCronRunner(
       workspace,
       worker


### PR DESCRIPTION
## Background
Worker cron runners are process-local, so updates on one server instance could leave other instances running stale cron expressions or worker code. This change adds Redis-backed lifecycle invalidation while keeping PostgreSQL authoritative.

## Changes
- Add a Worker cron lifecycle broadcast channel and event schema.
- Reconcile remote lifecycle events by reloading the full Worker row from PostgreSQL.
- Serialize per-worker lifecycle operations while allowing different workers to reconcile concurrently.
- Run full Worker cron reconciliation on startup and Redis recovery.
- Close the Worker broadcast transport during graceful shutdown.

## Testing
Adds focused Vitest coverage for Worker broadcast transport behavior and Worker cron manager reconciliation, queueing, publish ordering, deletion failure handling, and stale runner replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worker cron schedules and lifecycle changes now synchronize across server instances when Redis broadcasting is configured.
  - Worker runners reconcile automatically during startup, recovery, and remote lifecycle updates.
  - Worker create, update, start, stop, and delete changes propagate reliably across instances.

- **Bug Fixes**
  - Improved runner replacement, failure recovery, concurrent operation handling, and graceful shutdown behavior.

- **Tests**
  - Added comprehensive coverage for broadcasting, reconciliation, recovery, validation, serialization, and lifecycle operations.

- **Documentation**
  - Added implementation and design documentation for worker cron synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->