### PR TITLE
fix(insights): bind ClickHouse timezone parameters

### DIFF
--- a/src/server/model/insights/__snapshots__/website.spec.ts.snap
+++ b/src/server/model/insights/__snapshots__/website.spec.ts.snap
@@ -1,5 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`WebsiteInsightsSqlBuilder > builds complete ClickHouse SQL with a normal timezone > clickhouse sql with normal timezone 1`] = `
+{
+  "query": "select
+        formatDateTime(toStartOfDay("WebsiteEvent"."createdAt", {field0:String}), '%Y-%m-%d') date , count(1) as "$all_event"
+      from "WebsiteEvent"
+      where "WebsiteEvent"."websiteId" = {field1:String} AND "WebsiteEvent"."createdAt" BETWEEN toDateTime({field2:String}, 'UTC') AND toDateTime({field3:String}, 'UTC') AND (1 = 1)
+      group by 1
+      order by 1 desc
+      limit 1000",
+  "query_params": {
+    "field0": "Asia/Shanghai",
+    "field1": "cly5yay7a001v5tp6xdkzmygh",
+    "field2": "2025-02-10 16:00:00",
+    "field3": "2025-03-13 15:59:59",
+  },
+}
+`;
+
 exports[`WebsiteInsightsSqlBuilder > combined filters and groups > sql with filters and groups 1`] = `
 "select
         to_char(date_trunc('day', "WebsiteEvent"."createdAt" at time zone 'UTC'), 'YYYY-MM-DD') date , "WebsiteEventData"."stringValue" as "%browser" , count(1) as "$all_event"

--- a/src/server/model/insights/shared.ts
+++ b/src/server/model/insights/shared.ts
@@ -105,20 +105,19 @@ export abstract class InsightsSqlBuilder {
       CLICKHOUSE_DATE_FORMATS[unit as keyof typeof CLICKHOUSE_DATE_FORMATS];
 
     // ClickHouse uses different functions for date manipulation
-    // Use raw for string literals to avoid parameter binding issues
     if (unit === 'minute') {
-      return sql`formatDateTime(toStartOfMinute(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+      return sql`formatDateTime(toStartOfMinute(${raw(field)}, ${timezone}), '${raw(format)}')`;
     } else if (unit === 'hour') {
-      return sql`formatDateTime(toStartOfHour(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+      return sql`formatDateTime(toStartOfHour(${raw(field)}, ${timezone}), '${raw(format)}')`;
     } else if (unit === 'day') {
-      return sql`formatDateTime(toStartOfDay(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+      return sql`formatDateTime(toStartOfDay(${raw(field)}, ${timezone}), '${raw(format)}')`;
     } else if (unit === 'month') {
-      return sql`formatDateTime(toStartOfMonth(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+      return sql`formatDateTime(toStartOfMonth(${raw(field)}, ${timezone}), '${raw(format)}')`;
     } else if (unit === 'year') {
-      return sql`formatDateTime(toStartOfYear(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+      return sql`formatDateTime(toStartOfYear(${raw(field)}, ${timezone}), '${raw(format)}')`;
     }
 
-    return sql`formatDateTime(toStartOfDay(${raw(field)}, '${raw(timezone)}'), '${raw(format)}')`;
+    return sql`formatDateTime(toStartOfDay(${raw(field)}, ${timezone}), '${raw(format)}')`;
   }
 
   protected buildGroupByText(length: number): string {

--- a/src/server/model/insights/website.spec.ts
+++ b/src/server/model/insights/website.spec.ts
@@ -1,10 +1,110 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { unwrapSQL } from '../../utils/prisma.js';
 import { WebsiteInsightsSqlBuilder } from './website.js';
+import { clickhouse } from '../../clickhouse/index.js';
+
+class TestWebsiteInsightsSqlBuilder extends WebsiteInsightsSqlBuilder {
+  protected shouldUseClickhouse() {
+    return true;
+  }
+
+  public buildClickHouseDateQuery(unit: string, timezone: string) {
+    return this.getClickHouseDateQuery(
+      '"WebsiteEvent"."createdAt"',
+      unit,
+      timezone
+    );
+  }
+}
 
 describe('WebsiteInsightsSqlBuilder', () => {
   const insightId = 'cly5yay7a001v5tp6xdkzmygh';
   const insightType = 'website';
+
+  test.each(['minute', 'hour', 'day', 'month', 'year'])(
+    'binds the %s timezone in ClickHouse date queries',
+    (unit) => {
+      const maliciousTimezone =
+        'UTC\') UNION SELECT password FROM "User" -- ';
+      const builder = new TestWebsiteInsightsSqlBuilder(
+        {
+          insightId,
+          insightType,
+          workspaceId: '',
+          metrics: [],
+          filters: [],
+          time: {
+            startAt: 1739203200000,
+            endAt: 1741881599999,
+            unit: 'day',
+          },
+          groups: [],
+        },
+        {
+          timezone: 'UTC',
+        }
+      );
+
+      const query = builder.buildClickHouseDateQuery(
+        unit,
+        maliciousTimezone
+      );
+
+      expect(query.sql).not.toContain(maliciousTimezone);
+      expect(query.values).toEqual([maliciousTimezone]);
+    }
+  );
+
+  test('builds complete ClickHouse SQL with a normal timezone', async () => {
+    const timezone = 'Asia/Shanghai';
+    const builder = new TestWebsiteInsightsSqlBuilder(
+      {
+        insightId,
+        insightType,
+        workspaceId: '',
+        metrics: [
+          {
+            name: '$all_event',
+            math: 'events',
+          },
+        ],
+        filters: [],
+        time: {
+          startAt: 1739203200000,
+          endAt: 1741881599999,
+          unit: 'day',
+          timezone,
+        },
+        groups: [],
+      },
+      {
+        timezone: 'UTC',
+      }
+    );
+    let sentQuery: Parameters<typeof clickhouse.query>[0] | undefined;
+    const querySpy = vi.spyOn(clickhouse, 'query').mockImplementation(
+      async (query) => {
+        sentQuery = query;
+        return {
+          json: async () => ({ data: [] }),
+        } as never;
+      }
+    );
+
+    try {
+      await builder.executeQuery(builder.build());
+    } finally {
+      querySpy.mockRestore();
+    }
+
+    expect(sentQuery?.query_params).toMatchObject({
+      field0: timezone,
+    });
+    expect({
+      ...sentQuery,
+      query: sentQuery?.query.replace(/[ \t]+$/gm, ''),
+    }).toMatchSnapshot('clickhouse sql with normal timezone');
+  });
 
   test('groups', () => {
     const builder = new WebsiteInsightsSqlBuilder(


### PR DESCRIPTION
## Background
ClickHouse insight date bucketing interpolated timezone values directly into SQL, allowing crafted timezone strings to alter the generated query.

## Changes
- Bind ClickHouse timezone values as query parameters in date truncation helpers.
- Cover minute, hour, day, month, and year ClickHouse date query generation against malicious timezone input.
- Add an execution-level snapshot test verifying normal timezone values are sent through ClickHouse query params.

## Testing
- Added Vitest coverage in `src/server/model/insights/website.spec.ts` and updated the related snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone handling for date-based insights queries, ensuring timezone values are passed safely and consistently across supported date groupings.

* **Tests**
  * Added coverage validating timezone handling and generated ClickHouse queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->