### PR TITLE
fix(trpc): scope feed and warehouse authorization

### DIFF
--- a/src/server/trpc/routers/feed/authorization.spec.ts
+++ b/src/server/trpc/routers/feed/authorization.spec.ts
@@ -1,0 +1,367 @@
+import { createId } from '@paralleldrive/cuid2';
+import { FeedStateStatus } from '@prisma/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const endRequest = vi.fn();
+
+  return {
+    jwtVerify: vi.fn(() => ({
+      id: 'user-id',
+      username: 'user',
+      role: 'user',
+    })),
+    getWorkspaceUser: vi.fn(async () => ({ role: 'owner' })),
+    promStartTimer: vi.fn(() => endRequest),
+    fetchDataByCursor: vi.fn(),
+    feedStateResolve: vi.fn(),
+    prisma: {
+      feedChannel: {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        count: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
+      feedEvent: {
+        update: vi.fn(),
+        deleteMany: vi.fn(),
+      },
+      feedState: {
+        findMany: vi.fn(),
+      },
+    },
+  };
+});
+
+vi.mock('../../../middleware/auth.js', () => ({
+  jwtVerify: mocks.jwtVerify,
+}));
+
+vi.mock('../../../model/auth.js', () => ({
+  authConfig: {},
+}));
+
+vi.mock('../../../model/user.js', () => ({
+  verifyUserApiKey: vi.fn(),
+}));
+
+vi.mock('../../../model/workspace.js', () => ({
+  getWorkspaceUser: mocks.getWorkspaceUser,
+}));
+
+vi.mock('../../../utils/prometheus/client.js', () => ({
+  promTrpcRequest: {
+    startTimer: mocks.promStartTimer,
+  },
+}));
+
+vi.mock('../../../model/_client.js', () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock('../../../utils/prisma.js', () => ({
+  fetchDataByCursor: mocks.fetchDataByCursor,
+}));
+
+vi.mock('../../../model/feed/shared.js', () => ({
+  delFeedEventNotifyCache: vi.fn(),
+}));
+
+vi.mock('../../../model/billing/limit.js', () => ({
+  getWorkspaceTierLimit: vi.fn(),
+}));
+
+vi.mock('../../../model/billing/workspace.js', () => ({
+  isWorkspacePaused: vi.fn(async () => false),
+}));
+
+vi.mock('../../../model/feed/state.js', () => ({
+  feedStateResolve: mocks.feedStateResolve,
+  feedStateUpsert: vi.fn(),
+}));
+
+function channel(overrides: Partial<any> = {}) {
+  return {
+    id: 'channel-id',
+    workspaceId: createId(),
+    name: 'Alerts',
+    webhookSignature: '',
+    notifyFrequency: 'day',
+    publicShareId: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<any> = {}) {
+  return {
+    id: 'event-id',
+    channelId: 'channel-id',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    eventName: 'alert',
+    eventContent: 'victim data',
+    tags: [],
+    source: 'test',
+    senderId: null,
+    senderName: null,
+    url: null,
+    important: false,
+    archived: false,
+    payload: null,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<any> = {}) {
+  return {
+    id: 'state-id',
+    channelId: 'channel-id',
+    eventId: 'external-event-id',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    eventName: 'alert',
+    eventContent: 'victim data',
+    tags: [],
+    source: 'test',
+    senderId: null,
+    senderName: null,
+    url: null,
+    important: false,
+    payload: null,
+    status: FeedStateStatus.Ongoing,
+    resolvedAt: null,
+    ...overrides,
+  };
+}
+
+function mockVictimChannel(victimChannel: ReturnType<typeof channel>) {
+  mocks.prisma.feedChannel.findFirst.mockImplementation(
+    async ({ where }: any) =>
+      where.id === victimChannel.id &&
+      (where.workspaceId === undefined ||
+        where.workspaceId === victimChannel.workspaceId)
+        ? victimChannel
+        : null
+  );
+}
+
+async function createCaller() {
+  const { feedRouter } = await import('./index.js');
+
+  return feedRouter.createCaller({
+    token: 'jwt-token',
+    timezone: 'utc',
+    language: 'en',
+    req: { headers: {} } as any,
+    origin: '',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('feed channel authorization', () => {
+  test('rejects fetching events from another workspace channel', async () => {
+    const attackerWorkspaceId = createId();
+    const victimChannel = channel({ workspaceId: createId() });
+    const victimEvent = event({ channelId: victimChannel.id });
+    mockVictimChannel(victimChannel);
+    mocks.fetchDataByCursor.mockResolvedValue({
+      items: [victimEvent],
+      nextCursor: undefined,
+    });
+    const caller = await createCaller();
+
+    await expect(
+      caller.fetchEventsByCursor({
+        workspaceId: attackerWorkspaceId,
+        channelId: victimChannel.id,
+      })
+    ).rejects.toThrow('Channel not found');
+  });
+
+  test('rejects archiving an event from another workspace channel', async () => {
+    const attackerWorkspaceId = createId();
+    const victimChannel = channel({ workspaceId: createId() });
+    mockVictimChannel(victimChannel);
+    mocks.prisma.feedEvent.update.mockResolvedValue(
+      event({ channelId: victimChannel.id, archived: true })
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.archiveEvent({
+        workspaceId: attackerWorkspaceId,
+        channelId: victimChannel.id,
+        eventId: 'event-id',
+      })
+    ).rejects.toThrow('Channel not found');
+  });
+
+  test('rejects clearing archived events from another workspace channel', async () => {
+    const attackerWorkspaceId = createId();
+    const victimChannel = channel({ workspaceId: createId() });
+    mockVictimChannel(victimChannel);
+    mocks.prisma.feedEvent.deleteMany.mockResolvedValue({ count: 1 });
+    const caller = await createCaller();
+
+    await expect(
+      caller.clearAllArchivedEvents({
+        workspaceId: attackerWorkspaceId,
+        channelId: victimChannel.id,
+      })
+    ).rejects.toThrow('Channel not found');
+  });
+
+  test('rejects listing states from another workspace channel', async () => {
+    const attackerWorkspaceId = createId();
+    const victimChannel = channel({ workspaceId: createId() });
+    mockVictimChannel(victimChannel);
+    mocks.prisma.feedState.findMany.mockResolvedValue([
+      state({ channelId: victimChannel.id }),
+    ]);
+    const caller = await createCaller();
+
+    await expect(
+      caller.state.all({
+        workspaceId: attackerWorkspaceId,
+        channelId: victimChannel.id,
+      })
+    ).rejects.toThrow('Channel not found');
+  });
+
+  test('rejects resolving a state from another workspace channel', async () => {
+    const attackerWorkspaceId = createId();
+    const victimChannel = channel({ workspaceId: createId() });
+    mockVictimChannel(victimChannel);
+    mocks.feedStateResolve.mockResolvedValue(
+      state({ channelId: victimChannel.id, status: FeedStateStatus.Resolved })
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.state.resolve({
+        workspaceId: attackerWorkspaceId,
+        channelId: victimChannel.id,
+        stateId: 'state-id',
+      })
+    ).rejects.toThrow('Channel not found');
+  });
+
+  test('fetches events from a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    const currentEvent = event({ channelId: currentChannel.id });
+    mockVictimChannel(currentChannel);
+    mocks.fetchDataByCursor.mockResolvedValue({
+      items: [currentEvent],
+      nextCursor: undefined,
+    });
+    const caller = await createCaller();
+
+    const result = await caller.fetchEventsByCursor({
+      workspaceId,
+      channelId: currentChannel.id,
+    });
+
+    expect(result.items).toEqual([currentEvent]);
+  });
+
+  test('archives an event in a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    mockVictimChannel(currentChannel);
+    mocks.prisma.feedEvent.update.mockResolvedValue(
+      event({ channelId: currentChannel.id, archived: true })
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.archiveEvent({
+        workspaceId,
+        channelId: currentChannel.id,
+        eventId: 'event-id',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  test('unarchives an event in a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    mockVictimChannel(currentChannel);
+    mocks.prisma.feedEvent.update.mockResolvedValue(
+      event({ channelId: currentChannel.id, archived: false })
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.unarchiveEvent({
+        workspaceId,
+        channelId: currentChannel.id,
+        eventId: 'event-id',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  test('clears archived events from a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    mockVictimChannel(currentChannel);
+    mocks.prisma.feedEvent.deleteMany.mockResolvedValue({ count: 2 });
+    const caller = await createCaller();
+
+    const result = await caller.clearAllArchivedEvents({
+      workspaceId,
+      channelId: currentChannel.id,
+    });
+
+    expect(result).toBe(2);
+  });
+
+  test('lists states from a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    const currentState = state({ channelId: currentChannel.id });
+    mockVictimChannel(currentChannel);
+    mocks.prisma.feedState.findMany.mockResolvedValue([currentState]);
+    const caller = await createCaller();
+
+    const result = await caller.state.all({
+      workspaceId,
+      channelId: currentChannel.id,
+    });
+
+    expect(result).toEqual([currentState]);
+  });
+
+  test('resolves a state in a channel in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentChannel = channel({ workspaceId });
+    const resolvedState = state({
+      channelId: currentChannel.id,
+      status: FeedStateStatus.Resolved,
+      resolvedAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    mockVictimChannel(currentChannel);
+    mocks.feedStateResolve.mockResolvedValue(resolvedState);
+    const caller = await createCaller();
+
+    const result = await caller.state.resolve({
+      workspaceId,
+      channelId: currentChannel.id,
+      stateId: resolvedState.id,
+    });
+
+    expect(result).toEqual(resolvedState);
+  });
+});

--- a/src/server/trpc/routers/feed/index.ts
+++ b/src/server/trpc/routers/feed/index.ts
@@ -24,6 +24,7 @@ import { delFeedEventNotifyCache } from '../../../model/feed/shared.js';
 import { getWorkspaceTierLimit } from '../../../model/billing/limit.js';
 import { isWorkspacePaused } from '../../../model/billing/workspace.js';
 import { feedStateRouter } from './state.js';
+import { requireWorkspaceFeedChannel } from './shared.js';
 
 const PublicFeedChannelSchema = FeedChannelModelSchema.pick({
   id: true,
@@ -209,7 +210,9 @@ export const feedRouter = router({
       })
     )
     .query(async ({ input }) => {
-      const { channelId, cursor, limit, archived } = input;
+      const { workspaceId, channelId, cursor, limit, archived } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       const { items, nextCursor } = await fetchDataByCursor(prisma.feedEvent, {
         where: {
@@ -589,7 +592,9 @@ export const feedRouter = router({
     )
     .output(z.void())
     .mutation(async ({ input }) => {
-      const { channelId, eventId } = input;
+      const { workspaceId, channelId, eventId } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       await prisma.feedEvent.update({
         data: {
@@ -616,7 +621,9 @@ export const feedRouter = router({
     )
     .output(z.void())
     .mutation(async ({ input }) => {
-      const { channelId, eventId } = input;
+      const { workspaceId, channelId, eventId } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       await prisma.feedEvent.update({
         data: {
@@ -642,7 +649,9 @@ export const feedRouter = router({
     )
     .output(z.number())
     .mutation(async ({ input }) => {
-      const { channelId } = input;
+      const { workspaceId, channelId } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       const res = await prisma.feedEvent.deleteMany({
         where: {

--- a/src/server/trpc/routers/feed/shared.ts
+++ b/src/server/trpc/routers/feed/shared.ts
@@ -1,0 +1,24 @@
+import { TRPCError } from '@trpc/server';
+import { prisma } from '../../../model/_client.js';
+
+export async function requireWorkspaceFeedChannel(
+  workspaceId: string,
+  channelId: string
+) {
+  const channel = await prisma.feedChannel.findFirst({
+    where: {
+      id: channelId,
+      workspaceId,
+    },
+    select: { id: true },
+  });
+
+  if (!channel) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Channel not found',
+    });
+  }
+
+  return channel;
+}

--- a/src/server/trpc/routers/feed/state.ts
+++ b/src/server/trpc/routers/feed/state.ts
@@ -15,6 +15,7 @@ import {
   feedStateUpsert,
 } from '../../../model/feed/state.js';
 import { FeedStateStatus } from '@prisma/client';
+import { requireWorkspaceFeedChannel } from './shared.js';
 
 export const feedStateRouter = router({
   all: workspaceProcedure
@@ -33,7 +34,9 @@ export const feedStateRouter = router({
     )
     .output(FeedStateModelSchema.array())
     .query(async ({ input }) => {
-      const { channelId, limit } = input;
+      const { workspaceId, channelId, limit } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       const states = await prisma.feedState.findMany({
         where: {
@@ -129,6 +132,8 @@ export const feedStateRouter = router({
     .output(FeedStateModelSchema)
     .mutation(async ({ input }) => {
       const { workspaceId, channelId, stateId } = input;
+
+      await requireWorkspaceFeedChannel(workspaceId, channelId);
 
       const state = await feedStateResolve(workspaceId, channelId, stateId);
 

--- a/src/server/trpc/routers/insights/cohorts.spec.ts
+++ b/src/server/trpc/routers/insights/cohorts.spec.ts
@@ -1,0 +1,186 @@
+import { createId } from '@paralleldrive/cuid2';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const endRequest = vi.fn();
+
+  return {
+    jwtVerify: vi.fn(() => ({
+      id: 'user-id',
+      username: 'user',
+      role: 'user',
+    })),
+    getWorkspaceUser: vi.fn(async () => ({ role: 'owner' })),
+    promStartTimer: vi.fn(() => endRequest),
+    prisma: {
+      warehouseCohorts: {
+        update: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
+    },
+  };
+});
+
+vi.mock('../../../middleware/auth.js', () => ({
+  jwtVerify: mocks.jwtVerify,
+}));
+
+vi.mock('../../../model/auth.js', () => ({
+  authConfig: {},
+}));
+
+vi.mock('../../../model/user.js', () => ({
+  verifyUserApiKey: vi.fn(),
+}));
+
+vi.mock('../../../model/workspace.js', () => ({
+  getWorkspaceUser: mocks.getWorkspaceUser,
+}));
+
+vi.mock('../../../utils/prometheus/client.js', () => ({
+  promTrpcRequest: {
+    startTimer: mocks.promStartTimer,
+  },
+}));
+
+vi.mock('../../../model/_client.js', () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock('../../../model/insights/warehouse/cohorts.js', () => ({
+  getAllCohorts: vi.fn(),
+}));
+
+function cohort(overrides: Partial<any> = {}) {
+  return {
+    id: 'cohort-id',
+    name: 'Customers',
+    workspaceId: createId(),
+    warehouseApplicationId: 'app-id',
+    filter: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function matchesTenant(where: any, item: { id: string; workspaceId: string }) {
+  return (
+    where.id === item.id &&
+    (where.workspaceId === undefined || where.workspaceId === item.workspaceId)
+  );
+}
+
+async function createCaller() {
+  const { insightCohortsRouter } = await import('./cohorts.js');
+
+  return insightCohortsRouter.createCaller({
+    token: 'jwt-token',
+    timezone: 'utc',
+    language: 'en',
+    req: {} as any,
+    origin: '',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('warehouse cohort authorization', () => {
+  test('updates a cohort that belongs to the current workspace', async () => {
+    const workspaceId = createId();
+    const currentCohort = cohort({ workspaceId });
+    const updatedCohort = cohort({ workspaceId, name: 'Active customers' });
+    mocks.prisma.warehouseCohorts.update.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, currentCohort)) {
+          return updatedCohort;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    const result = await caller.upsert({
+      workspaceId,
+      id: currentCohort.id,
+      name: updatedCohort.name,
+      warehouseApplicationId: currentCohort.warehouseApplicationId,
+      filter: [],
+    });
+
+    expect(result).toEqual(updatedCohort);
+  });
+
+  test('deletes a cohort that belongs to the current workspace', async () => {
+    const workspaceId = createId();
+    const currentCohort = cohort({ workspaceId });
+    mocks.prisma.warehouseCohorts.delete.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, currentCohort)) {
+          return currentCohort;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    const result = await caller.delete({
+      workspaceId,
+      id: currentCohort.id,
+    });
+
+    expect(result).toEqual(currentCohort);
+  });
+
+  test('rejects updating a cohort that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimCohort = cohort({ workspaceId: createId() });
+    mocks.prisma.warehouseCohorts.update.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, victimCohort)) {
+          return victimCohort;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.upsert({
+        workspaceId: attackerWorkspaceId,
+        id: victimCohort.id,
+        name: 'Hijacked',
+        warehouseApplicationId: victimCohort.warehouseApplicationId,
+        filter: [],
+      })
+    ).rejects.toThrow('Record not found');
+  });
+
+  test('rejects deleting a cohort that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimCohort = cohort({ workspaceId: createId() });
+    mocks.prisma.warehouseCohorts.delete.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, victimCohort)) {
+          return victimCohort;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.delete({
+        workspaceId: attackerWorkspaceId,
+        id: victimCohort.id,
+      })
+    ).rejects.toThrow('Record not found');
+  });
+});

--- a/src/server/trpc/routers/insights/cohorts.ts
+++ b/src/server/trpc/routers/insights/cohorts.ts
@@ -32,6 +32,7 @@ export const insightCohortsRouter = router({
         const res = await prisma.warehouseCohorts.update({
           where: {
             id: input.id,
+            workspaceId: input.workspaceId,
           },
           data: {
             name: input.name,
@@ -60,7 +61,7 @@ export const insightCohortsRouter = router({
     .output(WarehouseCohortsModelSchema)
     .mutation(async ({ input }) => {
       const res = await prisma.warehouseCohorts.delete({
-        where: { id: input.id },
+        where: { id: input.id, workspaceId: input.workspaceId },
       });
 
       return res as unknown as z.infer<typeof WarehouseCohortsModelSchema>;

--- a/src/server/trpc/routers/insights/warehouse.spec.ts
+++ b/src/server/trpc/routers/insights/warehouse.spec.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
     pingWarehouse: vi.fn(async () => true),
     disposeWarehouseConnection: vi.fn(async () => {}),
     clearWarehouseTablesCache: vi.fn(),
+    getWarehouseConnection: vi.fn(),
     upsertWarehouseTable: vi.fn(async () => ({
       created: 0,
       updated: 0,
@@ -23,7 +24,12 @@ const mocks = vi.hoisted(() => {
     })),
     prisma: {
       warehouseDatabase: {
-        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+        update: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
+      warehouseDatabaseTable: {
         update: vi.fn(),
         create: vi.fn(),
         delete: vi.fn(),
@@ -66,8 +72,8 @@ vi.mock('../../../model/insights/warehouse/utils.js', () => ({
   pingWarehouse: mocks.pingWarehouse,
   disposeWarehouseConnection: mocks.disposeWarehouseConnection,
   clearWarehouseTablesCache: mocks.clearWarehouseTablesCache,
-  getWarehouseConnection: vi.fn(),
-  getMysqlFieldType: vi.fn(),
+  getWarehouseConnection: mocks.getWarehouseConnection,
+  getMysqlFieldType: vi.fn(() => 'varchar'),
   getPostgresqlFieldType: vi.fn(),
   extractSchemaFromUrl: vi.fn(() => 'public'),
 }));
@@ -84,6 +90,28 @@ function database(overrides: Partial<any> = {}) {
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     ...overrides,
   };
+}
+
+function databaseTable(overrides: Partial<any> = {}) {
+  return {
+    id: 'table-id',
+    workspaceId: createId(),
+    databaseId: 'database-id',
+    name: 'customers',
+    description: '',
+    ddl: '',
+    prompt: '',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function matchesTenant(where: any, item: { id: string; workspaceId: string }) {
+  return (
+    where.id === item.id &&
+    (where.workspaceId === undefined || where.workspaceId === item.workspaceId)
+  );
 }
 
 async function createCaller() {
@@ -111,7 +139,7 @@ describe('warehouse database router lifecycle', () => {
     const workspaceId = createId();
     const oldUri = 'mysql://old';
     const newUri = 'mysql://new';
-    mocks.prisma.warehouseDatabase.findUnique.mockResolvedValue(
+    mocks.prisma.warehouseDatabase.findFirst.mockResolvedValue(
       database({ workspaceId, connectionUri: oldUri })
     );
     mocks.prisma.warehouseDatabase.update.mockResolvedValue(
@@ -139,7 +167,7 @@ describe('warehouse database router lifecycle', () => {
   test('does not dispose the current connection when updating metadata only', async () => {
     const workspaceId = createId();
     const oldUri = 'mysql://old';
-    mocks.prisma.warehouseDatabase.findUnique.mockResolvedValue(
+    mocks.prisma.warehouseDatabase.findFirst.mockResolvedValue(
       database({ workspaceId, connectionUri: oldUri })
     );
     mocks.prisma.warehouseDatabase.update.mockResolvedValue(
@@ -173,5 +201,257 @@ describe('warehouse database router lifecycle', () => {
     });
 
     expect(mocks.disposeWarehouseConnection).toHaveBeenCalledWith(oldUri);
+  });
+});
+
+describe('warehouse database authorization', () => {
+  test('syncs a database that belongs to the current workspace', async () => {
+    const workspaceId = createId();
+    const currentDatabase = database({ workspaceId });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, currentDatabase) ? currentDatabase : null
+    );
+    const caller = await createCaller();
+
+    const result = await caller.database.sync({
+      workspaceId,
+      id: currentDatabase.id,
+    });
+
+    expect(result).toEqual({ created: 0, updated: 0, deleted: 0 });
+  });
+
+  test('rejects syncing a database that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimDatabase = database({ workspaceId: createId() });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, victimDatabase) ? victimDatabase : null
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.database.sync({
+        workspaceId: attackerWorkspaceId,
+        id: victimDatabase.id,
+      })
+    ).rejects.toThrow('Warehouse database not found');
+  });
+
+  test('rejects updating another workspace database before pinging its new URI', async () => {
+    const attackerWorkspaceId = createId();
+    const victimDatabase = database({ workspaceId: createId() });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, victimDatabase) ? victimDatabase : null
+    );
+    mocks.prisma.warehouseDatabase.update.mockResolvedValue(victimDatabase);
+    const caller = await createCaller();
+
+    await expect(
+      caller.database.upsert({
+        workspaceId: attackerWorkspaceId,
+        id: victimDatabase.id,
+        name: 'Hijacked',
+        connectionUri: 'mysql://attacker-controlled',
+      })
+    ).rejects.toThrow('Warehouse database not found');
+    expect(mocks.pingWarehouse).not.toHaveBeenCalled();
+  });
+
+  test('rejects deleting a database that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimDatabase = database({ workspaceId: createId() });
+    mocks.prisma.warehouseDatabase.delete.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, victimDatabase)) {
+          return victimDatabase;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.database.delete({
+        workspaceId: attackerWorkspaceId,
+        id: victimDatabase.id,
+      })
+    ).rejects.toThrow('Record not found');
+  });
+});
+
+describe('warehouse table authorization', () => {
+  test('updates a table that belongs to the current workspace', async () => {
+    const workspaceId = createId();
+    const currentTable = databaseTable({ workspaceId });
+    const updatedTable = databaseTable({
+      workspaceId,
+      name: 'renamed_customers',
+    });
+    mocks.prisma.warehouseDatabaseTable.update.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, currentTable)) {
+          return updatedTable;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    const result = await caller.table.upsert({
+      workspaceId,
+      id: currentTable.id,
+      databaseId: currentTable.databaseId,
+      name: updatedTable.name,
+    });
+
+    expect(result).toEqual(updatedTable);
+  });
+
+  test('deletes a table that belongs to the current workspace', async () => {
+    const workspaceId = createId();
+    const currentTable = databaseTable({ workspaceId });
+    mocks.prisma.warehouseDatabaseTable.delete.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, currentTable)) {
+          return currentTable;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    const result = await caller.table.delete({
+      workspaceId,
+      id: currentTable.id,
+    });
+
+    expect(result).toEqual(currentTable);
+  });
+
+  test('rejects creating a table for another workspace database', async () => {
+    const attackerWorkspaceId = createId();
+    const victimDatabase = database({ workspaceId: createId() });
+    const newTable = databaseTable({
+      workspaceId: attackerWorkspaceId,
+      databaseId: victimDatabase.id,
+    });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, victimDatabase) ? victimDatabase : null
+    );
+    mocks.prisma.warehouseDatabaseTable.create.mockResolvedValue(newTable);
+    const caller = await createCaller();
+
+    await expect(
+      caller.table.upsert({
+        workspaceId: attackerWorkspaceId,
+        databaseId: victimDatabase.id,
+        name: newTable.name,
+      })
+    ).rejects.toThrow('Warehouse database not found');
+  });
+
+  test('rejects updating a table that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimTable = databaseTable({ workspaceId: createId() });
+    mocks.prisma.warehouseDatabaseTable.update.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, victimTable)) {
+          return victimTable;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.table.upsert({
+        workspaceId: attackerWorkspaceId,
+        id: victimTable.id,
+        databaseId: victimTable.databaseId,
+        name: 'Hijacked',
+      })
+    ).rejects.toThrow('Record not found');
+  });
+
+  test('rejects deleting a table that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimTable = databaseTable({ workspaceId: createId() });
+    mocks.prisma.warehouseDatabaseTable.delete.mockImplementation(
+      async ({ where }: any) => {
+        if (matchesTenant(where, victimTable)) {
+          return victimTable;
+        }
+        throw new Error('Record not found');
+      }
+    );
+    const caller = await createCaller();
+
+    await expect(
+      caller.table.delete({
+        workspaceId: attackerWorkspaceId,
+        id: victimTable.id,
+      })
+    ).rejects.toThrow('Record not found');
+  });
+});
+
+describe('warehouse query authorization', () => {
+  test('rejects a database that belongs to another workspace', async () => {
+    const attackerWorkspaceId = createId();
+    const victimWorkspaceId = createId();
+    const victimDatabase = database({ workspaceId: victimWorkspaceId });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, victimDatabase) ? victimDatabase : null
+    );
+    mocks.getWarehouseConnection.mockReturnValue({
+      driver: 'mysql',
+      pool: {
+        query: vi.fn(async () => [
+          [{ secret: 'victim-data' }],
+          [{ name: 'secret', type: 253 }],
+        ]),
+      },
+    });
+    const caller = await createCaller();
+
+    await expect(
+      caller.query.execute({
+        workspaceId: attackerWorkspaceId,
+        databaseId: victimDatabase.id,
+        sql: 'SELECT secret FROM customers',
+      })
+    ).rejects.toThrow('Database connection not found');
+  });
+
+  test('executes a query against a database in the current workspace', async () => {
+    const workspaceId = createId();
+    const currentDatabase = database({ workspaceId });
+    mocks.prisma.warehouseDatabase.findFirst.mockImplementation(
+      async ({ where }: any) =>
+        matchesTenant(where, currentDatabase) ? currentDatabase : null
+    );
+    mocks.getWarehouseConnection.mockReturnValue({
+      driver: 'mysql',
+      pool: {
+        query: vi.fn(async () => [
+          [{ name: 'Alice' }],
+          [{ name: 'name', type: 253 }],
+        ]),
+      },
+    });
+    const caller = await createCaller();
+
+    const result = await caller.query.execute({
+      workspaceId,
+      databaseId: currentDatabase.id,
+      sql: 'SELECT name FROM customers',
+    });
+
+    expect(result.rows).toEqual([{ name: 'Alice' }]);
   });
 });

--- a/src/server/trpc/routers/insights/warehouse.ts
+++ b/src/server/trpc/routers/insights/warehouse.ts
@@ -62,8 +62,8 @@ export const warehouseRouter = router({
         })
       )
       .mutation(async ({ input }) => {
-        const db = await prisma.warehouseDatabase.findUnique({
-          where: { id: input.id },
+        const db = await prisma.warehouseDatabase.findFirst({
+          where: { id: input.id, workspaceId: input.workspaceId },
           select: { id: true, connectionUri: true },
         });
         if (!db) {
@@ -87,6 +87,18 @@ export const warehouseRouter = router({
       )
       .output(WarehouseDatebaseModelSchema)
       .mutation(async ({ input }) => {
+        let previousConnectionUri: string | undefined;
+        if (input.id) {
+          const previous = await prisma.warehouseDatabase.findFirst({
+            where: { id: input.id, workspaceId: input.workspaceId },
+            select: { connectionUri: true },
+          });
+          if (!previous) {
+            throw new Error('Warehouse database not found');
+          }
+          previousConnectionUri = previous.connectionUri;
+        }
+
         // only ping when connectionUri provided (create or update connection string)
         if (typeof input.connectionUri === 'string') {
           const isHealthy = await pingWarehouse(
@@ -99,15 +111,6 @@ export const warehouseRouter = router({
         }
 
         if (input.id) {
-          let previousConnectionUri: string | undefined;
-          if (typeof input.connectionUri === 'string') {
-            const previous = await prisma.warehouseDatabase.findUnique({
-              where: { id: input.id },
-              select: { connectionUri: true },
-            });
-            previousConnectionUri = previous?.connectionUri;
-          }
-
           const data: any = {
             name: input.name,
             description: input.description ?? '',
@@ -119,7 +122,7 @@ export const warehouseRouter = router({
             data.dbDriver = input.dbDriver;
           }
           const res = await prisma.warehouseDatabase.update({
-            where: { id: input.id },
+            where: { id: input.id, workspaceId: input.workspaceId },
             data,
           });
 
@@ -160,7 +163,7 @@ export const warehouseRouter = router({
       .output(WarehouseDatebaseModelSchema)
       .mutation(async ({ input }) => {
         const res = await prisma.warehouseDatabase.delete({
-          where: { id: input.id },
+          where: { id: input.id, workspaceId: input.workspaceId },
         });
         await disposeWarehouseConnection(res.connectionUri);
         return res;
@@ -191,7 +194,7 @@ export const warehouseRouter = router({
       .mutation(async ({ input }) => {
         if (input.id) {
           const res = await prisma.warehouseDatabaseTable.update({
-            where: { id: input.id },
+            where: { id: input.id, workspaceId: input.workspaceId },
             data: {
               name: input.name,
               description: input.description ?? '',
@@ -201,6 +204,17 @@ export const warehouseRouter = router({
           });
           return res;
         } else {
+          const database = await prisma.warehouseDatabase.findFirst({
+            where: {
+              id: input.databaseId,
+              workspaceId: input.workspaceId,
+            },
+            select: { id: true },
+          });
+          if (!database) {
+            throw new Error('Warehouse database not found');
+          }
+
           const res = await prisma.warehouseDatabaseTable.create({
             data: {
               workspaceId: input.workspaceId,
@@ -219,7 +233,7 @@ export const warehouseRouter = router({
       .output(WarehouseDatabaseTableModelSchema)
       .mutation(async ({ input }) => {
         const res = await prisma.warehouseDatabaseTable.delete({
-          where: { id: input.id },
+          where: { id: input.id, workspaceId: input.workspaceId },
         });
         return res;
       }),
@@ -246,7 +260,7 @@ export const warehouseRouter = router({
         })
       )
       .mutation(async ({ input }) => {
-        const { databaseId, sql } = input;
+        const { databaseId, sql, workspaceId } = input;
         const startTime = Date.now();
 
         // Validate SQL - only allow SELECT statements
@@ -271,8 +285,8 @@ export const warehouseRouter = router({
         }
 
         // Get database connection URI and driver
-        const database = await prisma.warehouseDatabase.findUnique({
-          where: { id: databaseId },
+        const database = await prisma.warehouseDatabase.findFirst({
+          where: { id: databaseId, workspaceId },
           select: { connectionUri: true, dbDriver: true },
         });
 


### PR DESCRIPTION
## Background
Feed and warehouse mutations could address records by id without consistently verifying that the target resource belongs to the active workspace.

## Changes
- Add a shared feed channel ownership check and apply it to event fetching, archiving, clearing archived events, state listing, and state resolution.
- Scope warehouse database sync, update, delete, and query execution by workspace.
- Scope warehouse table and cohort update/delete operations by workspace.
- Validate the parent warehouse database belongs to the workspace before creating a table.
- Avoid pinging an updated warehouse connection URI when the database id is not owned by the workspace.

## Testing
Patch adds Vitest coverage for cross-workspace rejection and same-workspace success paths for feed authorization, warehouse databases/tables/queries, and warehouse cohorts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened workspace access controls for feed channels, cohorts, warehouse databases, tables, and queries.
  * Prevented cross-workspace access to feed events, state operations, cohort records, and warehouse resources.
  * Ensured warehouse updates, deletions, and connections only affect resources within the active workspace.

* **Tests**
  * Added comprehensive coverage for authorized same-workspace actions and rejected cross-workspace operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->