### PR TITLE
feat(worker): add scoped worker kv cache

### DIFF
--- a/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
+++ b/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
@@ -8,8 +8,13 @@ short-lived state with another Worker in the same Workspace.
 
 Tianji already has a shared Keyv cache manager. It uses Redis when `REDIS_URL`
 is configured, PostgreSQL otherwise, and an in-process map in memory-only
-deployments. Workers should reuse this capability without receiving direct
-access to Keyv or to Tianji's internal cache keys.
+deployments. Workers reuse the configured store and namespace through a
+Worker-only Keyv wrapper with `throwOnErrors: true`. Because `@keyv/redis` also
+has an adapter-level error policy, Redis deployments use a strict adapter view
+over the configured shared client. Neither path opens a second backend
+connection nor changes the shared manager's error behavior.
+Workers do not receive direct access to Keyv or to Tianji's internal cache
+keys.
 
 ## Goals
 
@@ -95,23 +100,39 @@ override either identity.
 Add a Worker-specific KV facade outside the isolate. The facade receives a
 trusted execution scope containing the Workspace ID, Worker ID, execution type,
 and test namespace where applicable. It validates every operation, constructs a
-logical key, and delegates to the existing `getCacheManager()`.
+logical key, and delegates to a strict Keyv wrapper over the store returned by
+the existing `getCacheManager()`.
 
-Logical keys use versioned namespaces:
+Logical keys use versioned namespaces and a SHA-256 hex digest of the validated
+user key's UTF-16LE code units. Hashing code units preserves the existing
+JavaScript `string.length` contract without collapsing distinct accepted lone
+surrogates:
 
 ```text
-worker-kv:v1:<workspaceId>:<workerId>:<userKey>
-workspace-kv:v1:<workspaceId>:<userKey>
+worker-kv:v1:<workspaceId>:<workerId>:<sha256(userKey)>
+workspace-kv:v1:<workspaceId>:<sha256(userKey)>
 ```
 
-The existing Keyv namespace remains responsible for the final physical prefix.
-The facade never exposes constructed keys, backend clients, or backend errors to
-the sandbox.
+Test scopes retain their execution identity before the same digest. Hashing only
+the user-controlled suffix keeps maximum-length and NUL-containing logical keys
+safe for PostgreSQL's `VARCHAR(255)` key column. With the schema's 30-character
+identity bounds, the longest current physical key is 167 characters. The
+existing `tianji-cache` Keyv namespace remains responsible for the final
+physical prefix. The facade never exposes constructed keys, backend clients, or
+backend errors to the sandbox.
 
-The facade is injected into `runCodeInIVM()` as a host object. Its methods use
-the existing isolated-vm reference bridge and return only transferable plain
-values. The Worker editor's sandbox declaration is updated so the API has type
-checking and completion.
+The facade is injected into `runCodeInIVM()` through null-prototype host objects.
+Before isolated-vm copies arguments, an isolate-side wrapper validates values
+and builds a descriptor-safe, null-prototype copy before JSON encoding. This
+rejects accessors, hidden serialization hooks, and inherited `toJSON` hooks
+without executing them. Invalid values invoke the host with only clone-safe
+sentinel data, so the host still performs authoritative validation and consumes
+the shared call budget. Valid values are parsed and validated again on the host
+before storage. Raw bridge globals are deleted inside a nested installer before
+Worker code runs, and Worker source executes in a separate nested async scope so
+its hoisted declarations and shadowed built-ins cannot intercept installation.
+The public `kv` scopes expose no inherited methods. The Worker editor's sandbox
+declaration is updated so the API has type checking and completion.
 
 ## Data and TTL Semantics
 
@@ -142,9 +163,20 @@ remain subject to the normal TTL and are not promised to be available to a
 later test execution.
 
 Updating or rolling back a Worker preserves its cache because the Worker ID is
-unchanged. Deleting a Worker does not scan the backend for its private keys;
-those entries become unreadable according to their TTL, which is at most one
-day. Workspace entries are not tied to the lifecycle of any one Worker.
+unchanged. Deleting a Worker does not run an unbounded per-Worker scan; those
+entries become unreadable and expire within one day. Workspace entries are not
+tied to the lifecycle of any one Worker.
+
+Because `@keyv/postgres` stores expiry inside its serialized value, PostgreSQL
+deployments also run bounded expiry maintenance against the existing
+`cache.cache` table. After a successful Worker KV store operation, at most once
+per minute per process, Tianji schedules one 100-row delete through the existing
+Prisma connection. The parameterized query selects only expired rows whose keys
+begin with the versioned Worker-private, Workspace-shared, or Worker-test
+prefixes under `tianji-cache`; it uses one in-process single flight and
+`FOR UPDATE SKIP LOCKED`. Redis and memory-only deployments do not run this SQL.
+Cleanup failure is contained, rate limited, and logged only as a stable generic
+warning, so it cannot fail an otherwise valid Worker operation.
 
 ## Resource Limits
 
@@ -168,6 +200,14 @@ timeouts reject the Worker API call. A backend failure is never converted into
 a cache miss because callers may use the cache for idempotency or duplicate
 suppression. Worker code can explicitly catch an error when best-effort cache
 behavior is appropriate.
+
+Worker operations use a strict Keyv wrapper over a forwarding view of the
+already-configured store. For Redis, that forwarding path uses a second strict
+adapter instance over the same client and copies the existing namespace and key
+options; Worker operations still use the same configured client and never open a
+second connection. This preserves the shared singleton's existing error behavior
+for non-Worker consumers while making rejected adapter operations and false
+write results fail closed for Workers.
 
 Errors returned to the isolate are stable and sanitized. They identify the
 operation category without including physical keys, cached values, database
@@ -194,13 +234,21 @@ proof that a write did not occur.
 Add focused tests covering:
 
 - Private and Workspace logical key construction.
+- SHA-256 determinism, distinct-key behavior, 256-character and NUL-containing
+  keys, and the PostgreSQL physical-key bound.
 - Isolation across Workers and across Workspaces.
 - Default TTL, the 1-second minimum, and the 1-day maximum.
 - Key, JSON value, finite-number, per-value, operation-count, and cumulative
   write validations.
 - Missing entries, deletion results, and last-write-wins behavior.
 - Sanitized backend failure and timeout errors.
-- `kv` and `kv.workspace` calls across the isolated-vm bridge.
+- Real Keyv rejection behavior and false write results.
+- PostgreSQL cleanup gating, prefix and expiry restrictions, bounded batches,
+  rate limiting, single flight, and safe failure.
+- `kv` and `kv.workspace` calls through actual `execWorker`/isolated-vm,
+  including clone-sensitive values, serialization hooks, repeated references,
+  call accounting, hidden raw/inherited bridge surfaces, hoisted declarations,
+  and shadowed built-ins.
 - Correct identity propagation for HTTP, manual, and cron execution.
 - Per-execution test namespaces that cannot access live cache entries.
 - Editor sandbox declarations matching the runtime API.

--- a/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
+++ b/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
@@ -123,11 +123,13 @@ backend errors to the sandbox.
 
 The facade is injected into `runCodeInIVM()` through null-prototype host objects.
 Before isolated-vm copies arguments, an isolate-side wrapper validates values
-and builds a descriptor-safe, null-prototype copy before JSON encoding. This
-rejects accessors, hidden serialization hooks, and inherited `toJSON` hooks
-without executing them. Invalid values invoke the host with only clone-safe
-sentinel data, so the host still performs authoritative validation and consumes
-the shared call budget. Valid values are parsed and validated again on the host
+and builds a descriptor-safe, null-prototype copy before JSON encoding. It also
+checks key length and counts the encoded value's UTF-8 bytes before either
+argument crosses the isolate boundary. This rejects oversized transfers,
+accessors, hidden serialization hooks, and inherited `toJSON` hooks without
+executing them. Invalid values invoke the host with only clone-safe sentinel
+data, so the host still performs authoritative validation and consumes the
+shared call budget. Valid values are parsed and validated again on the host
 before storage. Raw bridge globals are deleted inside a nested installer before
 Worker code runs, and Worker source executes in a separate nested async scope so
 its hoisted declarations and shadowed built-ins cannot intercept installation.
@@ -170,13 +172,17 @@ tied to the lifecycle of any one Worker.
 Because `@keyv/postgres` stores expiry inside its serialized value, PostgreSQL
 deployments also run bounded expiry maintenance against the existing
 `cache.cache` table. After a successful Worker KV store operation, at most once
-per minute per process, Tianji schedules one 100-row delete through the existing
-Prisma connection. The parameterized query selects only expired rows whose keys
-begin with the versioned Worker-private, Workspace-shared, or Worker-test
-prefixes under `tianji-cache`; it uses one in-process single flight and
-`FOR UPDATE SKIP LOCKED`. Redis and memory-only deployments do not run this SQL.
-Cleanup failure is contained, rate limited, and logged only as a stable generic
-warning, so it cannot fail an otherwise valid Worker operation.
+per minute per process, Tianji scans one keyset-paginated 100-row range through
+the existing Prisma connection. The three versioned Worker-private,
+Workspace-shared, and Worker-test prefixes have independent cursors and are
+visited in rotation. Expiry JSON is evaluated only inside the materialized
+100-row batch, and expired rows in that batch are deleted with
+`FOR UPDATE SKIP LOCKED`. Redis deployments rely on native TTL. Memory-only
+deployments use per-key, unref'ed expiry timers in the Worker forwarding adapter
+so high-cardinality and one-time test keys are actively removed instead of
+remaining in the shared `Map` until a future read. Cleanup failure is contained,
+rate limited, and logged only as a stable generic warning, so it cannot fail an
+otherwise valid Worker operation.
 
 ## Resource Limits
 

--- a/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
+++ b/docs/superpowers/specs/2026-08-15-worker-kv-cache-design.md
@@ -1,0 +1,210 @@
+# Worker KV Cache
+
+## Problem
+
+Tianji Function Workers are isolated executions. They cannot currently retain
+short-lived state between HTTP, manual, and cron invocations, or share
+short-lived state with another Worker in the same Workspace.
+
+Tianji already has a shared Keyv cache manager. It uses Redis when `REDIS_URL`
+is configured, PostgreSQL otherwise, and an in-process map in memory-only
+deployments. Workers should reuse this capability without receiving direct
+access to Keyv or to Tianji's internal cache keys.
+
+## Goals
+
+- Expose a small asynchronous KV cache API inside Function Workers.
+- Make the current Worker the safe default scope.
+- Allow explicit sharing between Workers in the same Workspace.
+- Preserve the existing Redis, PostgreSQL, and memory-only backend selection.
+- Bound cache lifetime, payload size, operation count, and backend latency.
+- Keep tenant identity and physical key construction outside the sandbox.
+- Make the API available consistently to HTTP, manual, cron, and code-test
+  executions.
+
+## Non-goals
+
+- Durable or permanent Worker storage.
+- Transactions, compare-and-swap, atomic increments, or cross-key consistency.
+- Listing keys, clearing a namespace, or providing a cache management UI.
+- Per-Workspace storage accounting or a new Worker KV database table.
+- Exposing raw Keyv, Redis, or PostgreSQL clients to Worker code.
+- Extending the VM2 runtime, which is not used by the current Worker execution
+  path.
+
+## Alternatives Considered
+
+### Separate Worker and Workspace APIs
+
+Expose `kv` for the current Worker and `kv.workspace` for explicit Workspace
+sharing. This is the selected approach because private access is the shortest
+and safest call, while shared access remains conspicuous during code review.
+
+### Scope Option on Every Operation
+
+An API such as `kv.get(key, { scope: 'workspace' })` has fewer surface objects,
+but dynamic scope values are easier to pass accidentally and make shared access
+less obvious.
+
+### Dedicated Worker KV Table
+
+A dedicated table could support quotas, administration, and richer queries, but
+it would duplicate Tianji's existing cache backend and introduce durable-storage
+semantics that are outside this feature.
+
+## Worker API
+
+The Worker editor and sandbox expose the following interface:
+
+```ts
+type KVValue =
+  | null
+  | string
+  | number
+  | boolean
+  | KVValue[]
+  | { [key: string]: KVValue };
+
+interface KVScope {
+  get<T extends KVValue = KVValue>(key: string): Promise<T | undefined>;
+  set(key: string, value: KVValue, ttl?: number): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+declare const kv: KVScope & {
+  workspace: KVScope;
+};
+```
+
+Examples:
+
+```ts
+await kv.set('last-result', result);
+const previous = await kv.get('last-result');
+
+await kv.workspace.set('shared-token', token, 60_000);
+const sharedToken = await kv.workspace.get('shared-token');
+```
+
+`kv.*` operates on the current Worker. `kv.workspace.*` operates on a namespace
+shared by all Workers in the current Workspace. Worker code cannot supply or
+override either identity.
+
+## Architecture
+
+Add a Worker-specific KV facade outside the isolate. The facade receives a
+trusted execution scope containing the Workspace ID, Worker ID, execution type,
+and test namespace where applicable. It validates every operation, constructs a
+logical key, and delegates to the existing `getCacheManager()`.
+
+Logical keys use versioned namespaces:
+
+```text
+worker-kv:v1:<workspaceId>:<workerId>:<userKey>
+workspace-kv:v1:<workspaceId>:<userKey>
+```
+
+The existing Keyv namespace remains responsible for the final physical prefix.
+The facade never exposes constructed keys, backend clients, or backend errors to
+the sandbox.
+
+The facade is injected into `runCodeInIVM()` as a host object. Its methods use
+the existing isolated-vm reference bridge and return only transferable plain
+values. The Worker editor's sandbox declaration is updated so the API has type
+checking and completion.
+
+## Data and TTL Semantics
+
+- The default TTL is 10 minutes.
+- An explicit TTL is expressed in milliseconds.
+- The minimum TTL is 1 second and the maximum TTL is 1 day.
+- A missing or expired entry returns `undefined`.
+- Keys must be non-empty strings no longer than 256 characters.
+- Values must be JSON-compatible plain data and encode to at most 256 KiB.
+- Numbers must be finite.
+- `undefined`, functions, symbols, bigints, binary values, class instances, and
+  cyclic data are rejected.
+- Serialized UTF-8 JSON size is used for the value and write-budget checks.
+
+Concurrent writes to one key use last-write-wins semantics. No read-modify-write
+atomicity is promised.
+
+## Execution Scopes
+
+HTTP, manual, and cron execution pass the persisted Worker's Workspace ID and
+Worker ID to the facade. All three entry points therefore observe the same
+private and Workspace-shared cache entries.
+
+Code-test execution uses an unguessable, per-execution test namespace for both
+API levels. A test can verify `set`, `get`, and `delete` within one execution,
+but it cannot read or mutate live Worker or Workspace cache entries. Test keys
+remain subject to the normal TTL and are not promised to be available to a
+later test execution.
+
+Updating or rolling back a Worker preserves its cache because the Worker ID is
+unchanged. Deleting a Worker does not scan the backend for its private keys;
+those entries become unreadable according to their TTL, which is at most one
+day. Workspace entries are not tied to the lifecycle of any one Worker.
+
+## Resource Limits
+
+Each Worker execution has one shared budget across private and Workspace
+operations:
+
+- At most 50 KV API calls.
+- At most 1 MiB of cumulative serialized writes.
+- At most 256 KiB per value.
+- At most 2 seconds waiting for each backend operation.
+
+Rejected validation and budget checks count as calls but do not reach the
+backend. These limits reduce accidental loops and storage amplification while
+keeping the first version backend-neutral. They are not a substitute for route
+rate limiting or durable per-Workspace quotas.
+
+## Failure Semantics
+
+Invalid keys, values, TTLs, exhausted budgets, backend failures, and operation
+timeouts reject the Worker API call. A backend failure is never converted into
+a cache miss because callers may use the cache for idempotency or duplicate
+suppression. Worker code can explicitly catch an error when best-effort cache
+behavior is appropriate.
+
+Errors returned to the isolate are stable and sanitized. They identify the
+operation category without including physical keys, cached values, database
+details, Redis URLs, hostnames, or credentials. Server logs likewise avoid
+values and secret-bearing connection details.
+
+As with other remote stores, timing out the caller cannot guarantee that an
+already-issued backend write was cancelled. Callers must not treat a timeout as
+proof that a write did not occur.
+
+## Security Boundaries
+
+- Workspace and Worker identity come only from the server's persisted Worker
+  lookup or cron runner, never from the request payload or Worker code.
+- Namespace construction happens outside the sandbox.
+- Worker code cannot access Tianji query caches, cron state, distributed locks,
+  or another Workspace's keys.
+- A public Worker can access its Workspace cache only when its trusted saved
+  code calls `kv.workspace`; an external caller cannot select a scope directly.
+- User-controlled keys and values remain bounded and are never written to logs.
+
+## Tests and Verification
+
+Add focused tests covering:
+
+- Private and Workspace logical key construction.
+- Isolation across Workers and across Workspaces.
+- Default TTL, the 1-second minimum, and the 1-day maximum.
+- Key, JSON value, finite-number, per-value, operation-count, and cumulative
+  write validations.
+- Missing entries, deletion results, and last-write-wins behavior.
+- Sanitized backend failure and timeout errors.
+- `kv` and `kv.workspace` calls across the isolated-vm bridge.
+- Correct identity propagation for HTTP, manual, and cron execution.
+- Per-execution test namespaces that cannot access live cache entries.
+- Editor sandbox declarations matching the runtime API.
+
+Run the focused server and VM Vitest suites first, then run `pnpm check:type`
+and `pnpm build` as required by the contributor guide. Do not modify locale JSON
+files.

--- a/src/client/components/CodeEditor/lib/sandbox.spec.tsx
+++ b/src/client/components/CodeEditor/lib/sandbox.spec.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vitest';
+import { sandboxGlobal } from './sandbox';
+
+describe('Worker sandbox declarations', () => {
+  test('declares the two-level KV API', () => {
+    expect(sandboxGlobal).toContain('interface KVScope');
+    expect(sandboxGlobal).toContain('Promise<T | undefined>');
+    expect(sandboxGlobal).toContain('ttl?: number');
+    expect(sandboxGlobal).toContain('declare const kv: KVScope &');
+    expect(sandboxGlobal).toContain('workspace: KVScope');
+  });
+});

--- a/src/client/components/CodeEditor/lib/sandbox.ts
+++ b/src/client/components/CodeEditor/lib/sandbox.ts
@@ -72,5 +72,23 @@ declare function request(config: AxiosConfig): Promise<RequestReturn>;
 
 const request = async (config: AxiosConfig): Promise<RequestReturn> => {};
 
+type KVValue =
+  | null
+  | string
+  | number
+  | boolean
+  | KVValue[]
+  | { [key: string]: KVValue };
+
+interface KVScope {
+  get<T extends KVValue = KVValue>(key: string): Promise<T | undefined>;
+  set(key: string, value: KVValue, ttl?: number): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+declare const kv: KVScope & {
+  workspace: KVScope;
+};
+
 declare function fetch(params: Record<string, any>, ctx: FetchContext): Promise<string>;
 `;

--- a/src/server/cache/index.ts
+++ b/src/server/cache/index.ts
@@ -2,8 +2,13 @@ import Keyv, { type KeyvStoreAdapter } from 'keyv';
 import KeyvRedis from '@keyv/redis';
 import KeyvPostgres from '@keyv/postgres';
 import { env } from '../utils/env.js';
+import {
+  createWorkerCacheManager,
+  scheduleWorkerKVPostgresCleanup,
+} from './worker.js';
 
 let _cacheManager: Keyv;
+let _workerCacheManager: Keyv;
 export async function getCacheManager() {
   if (_cacheManager) {
     return _cacheManager;
@@ -31,6 +36,20 @@ export async function getCacheManager() {
   _cacheManager = cacheManager;
 
   return cacheManager;
+}
+
+export async function getWorkerCacheManager() {
+  if (_workerCacheManager) {
+    return _workerCacheManager;
+  }
+
+  const shared = await getCacheManager();
+  _workerCacheManager = createWorkerCacheManager(
+    shared,
+    scheduleWorkerKVPostgresCleanup
+  );
+
+  return _workerCacheManager;
 }
 
 interface BuildQueryWithCacheOptions {

--- a/src/server/cache/index.worker.spec.ts
+++ b/src/server/cache/index.worker.spec.ts
@@ -1,0 +1,40 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const workerCacheMocks = vi.hoisted(() => ({
+  createWorkerCacheManager: vi.fn(),
+  scheduleWorkerKVPostgresCleanup: vi.fn(),
+}));
+
+vi.mock('../utils/env.js', () => ({
+  env: {
+    cache: {
+      memoryOnly: true,
+      redisUrl: undefined,
+    },
+  },
+}));
+
+vi.mock('./worker.js', () => workerCacheMocks);
+
+import { getCacheManager, getWorkerCacheManager } from './index.js';
+
+describe('getWorkerCacheManager', () => {
+  beforeAll(() => {
+    workerCacheMocks.createWorkerCacheManager.mockImplementation(
+      (shared) => shared
+    );
+  });
+
+  it('memoizes the Worker facade with PostgreSQL maintenance wiring', async () => {
+    const shared = await getCacheManager();
+
+    await expect(getWorkerCacheManager()).resolves.toBe(shared);
+    await expect(getWorkerCacheManager()).resolves.toBe(shared);
+
+    expect(workerCacheMocks.createWorkerCacheManager).toHaveBeenCalledOnce();
+    expect(workerCacheMocks.createWorkerCacheManager).toHaveBeenCalledWith(
+      shared,
+      workerCacheMocks.scheduleWorkerKVPostgresCleanup
+    );
+  });
+});

--- a/src/server/cache/worker.spec.ts
+++ b/src/server/cache/worker.spec.ts
@@ -48,6 +48,25 @@ describe('createWorkerCacheManager', () => {
     expect(maintenance).toHaveBeenCalledTimes(3);
   });
 
+  it('actively removes expired Worker entries from the shared memory store', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new Map();
+      const shared = new Keyv({ store, namespace: 'tianji-cache' });
+      const worker = createWorkerCacheManager(shared);
+
+      await worker.set('worker-key', 'value', 1_000);
+      expect(store.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(store.size).toBe(0);
+      await expect(shared.get('worker-key')).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each(['get', 'set', 'delete'] as const)(
     'uses a strict Redis adapter view for %s without mutating the shared adapter',
     async (method) => {
@@ -137,9 +156,11 @@ describe('createWorkerKVPostgresCleanup', () => {
     expect(isWorkerKVPostgresStore(maintenance.mock.calls[0][0])).toBe(true);
   });
 
-  it('gates PostgreSQL and issues a bounded prefix-restricted expiry delete', async () => {
+  it('gates PostgreSQL and scans one bounded prefix range before deleting expiry rows', async () => {
     const postgresStore = {};
-    const execute = vi.fn(async (_query: unknown) => 3);
+    const execute = vi.fn(async (_query: unknown) => [
+      { lastKey: null, scannedCount: 0, deletedCount: 0 },
+    ]);
     const cleanup = createWorkerKVPostgresCleanup({
       isPostgresStore: (store) => store === postgresStore,
       execute,
@@ -161,25 +182,67 @@ describe('createWorkerKVPostgresCleanup', () => {
     };
     const sql = query.strings.join('?').replace(/\s+/g, ' ').trim();
 
-    expect(sql).toContain('DELETE FROM "cache"."cache"');
+    expect(sql).toContain('WITH worker_kv_batch AS MATERIALIZED');
+    expect(sql).toContain('WHERE "key" > ? AND "key" < ?');
+    expect(sql).toContain('LIMIT ? FOR UPDATE SKIP LOCKED');
+    expect(sql).toContain('DELETE FROM "cache"."cache" AS target');
     expect(sql).toContain(
-      'WHERE ( "key" LIKE ? OR "key" LIKE ? OR "key" LIKE ? )'
+      "WHEN jsonb_typeof(candidate.\"value\"::jsonb -> 'expires') = 'number'"
     );
     expect(sql).toContain(
-      "WHEN jsonb_typeof(\"value\"::jsonb -> 'expires') = 'number'"
+      'THEN (candidate."value"::jsonb ->> \'expires\')::bigint < ?'
     );
-    expect(sql).toContain(
-      'THEN ("value"::jsonb ->> \'expires\')::bigint < ?'
-    );
-    expect(sql).toContain('LIMIT ?');
-    expect(sql).toContain('FOR UPDATE SKIP LOCKED');
     expect(query.values).toEqual([
-      'tianji-cache:worker-kv:v1:%',
-      'tianji-cache:workspace-kv:v1:%',
-      'tianji-cache:worker-kv-test:v1:%',
-      1_765_843_200_000,
+      'tianji-cache:worker-kv:v1:',
+      'tianji-cache:worker-kv:v1:\uffff',
       100,
+      1_765_843_200_000,
     ]);
+  });
+
+  it('continues a full prefix batch by cursor and rotates after a short batch', async () => {
+    const postgresStore = {};
+    let currentTime = 10_000;
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          lastKey: 'tianji-cache:worker-kv:v1:last-key',
+          scannedCount: 100,
+          deletedCount: 10,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          lastKey: 'tianji-cache:worker-kv:v1:tail',
+          scannedCount: 2,
+          deletedCount: 1,
+        },
+      ])
+      .mockResolvedValueOnce([
+        { lastKey: null, scannedCount: 0, deletedCount: 0 },
+      ]);
+    const cleanup = createWorkerKVPostgresCleanup({
+      isPostgresStore: (store) => store === postgresStore,
+      execute,
+      now: () => currentTime,
+      intervalMs: 60_000,
+      batchSize: 100,
+      warn: vi.fn(),
+    });
+
+    await cleanup(postgresStore);
+    currentTime += 60_000;
+    await cleanup(postgresStore);
+    currentTime += 60_000;
+    await cleanup(postgresStore);
+
+    const values = execute.mock.calls.map(
+      (call) => (call[0] as { values: readonly unknown[] }).values
+    );
+    expect(values[0][0]).toBe('tianji-cache:worker-kv:v1:');
+    expect(values[1][0]).toBe('tianji-cache:worker-kv:v1:last-key');
+    expect(values[2][0]).toBe('tianji-cache:workspace-kv:v1:');
   });
 
   it('rate limits attempts and shares one in-flight cleanup', async () => {

--- a/src/server/cache/worker.spec.ts
+++ b/src/server/cache/worker.spec.ts
@@ -1,0 +1,244 @@
+import EventEmitter from 'node:events';
+import Keyv from 'keyv';
+import KeyvPostgres from '@keyv/postgres';
+import KeyvRedis from '@keyv/redis';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createWorkerCacheManager,
+  createWorkerKVPostgresCleanup,
+  isWorkerKVPostgresStore,
+} from './worker.js';
+
+describe('createWorkerCacheManager', () => {
+  it('shares the configured store and namespace without changing shared error behavior', async () => {
+    const store = new Map() as Map<unknown, unknown> & {
+      namespace?: string;
+    };
+    const shared = new Keyv({
+      store,
+      namespace: 'tianji-cache',
+    });
+    const sharedStoreNamespace = store.namespace;
+
+    const worker = createWorkerCacheManager(shared);
+
+    expect(worker.store).not.toBe(shared.store);
+    expect(worker.namespace).toBe('tianji-cache');
+    expect(worker.throwOnErrors).toBe(true);
+    expect(shared.throwOnErrors).toBe(false);
+    expect(store.namespace).toBe(sharedStoreNamespace);
+
+    await worker.set('worker-key', 'value');
+    await expect(shared.get('worker-key')).resolves.toBe('value');
+  });
+
+  it('keeps successful operations valid when maintenance throws', async () => {
+    const shared = new Keyv({
+      store: new Map(),
+      namespace: 'tianji-cache',
+    });
+    const maintenance = vi.fn(() => {
+      throw new Error('database details');
+    });
+    const worker = createWorkerCacheManager(shared, maintenance);
+
+    await expect(worker.set('key', 'value')).resolves.toBe(true);
+    await expect(worker.get('key')).resolves.toBe('value');
+    await expect(worker.delete('key')).resolves.toBe(true);
+    expect(maintenance).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(['get', 'set', 'delete'] as const)(
+    'uses a strict Redis adapter view for %s without mutating the shared adapter',
+    async (method) => {
+      const client = Object.assign(new EventEmitter(), {
+        isOpen: true,
+        options: { url: 'redis://cache.internal' },
+        connect: vi.fn(),
+        get: vi.fn(async () => {
+          throw new Error('redis unavailable');
+        }),
+        set: vi.fn(async () => {
+          throw new Error('redis unavailable');
+        }),
+        del: vi.fn(async () => {
+          throw new Error('redis unavailable');
+        }),
+        unlink: vi.fn(async () => {
+          throw new Error('redis unavailable');
+        }),
+      });
+      const sharedStore = new KeyvRedis(client as any, {
+        throwOnErrors: false,
+      });
+      const shared = new Keyv({
+        store: sharedStore,
+        namespace: 'tianji-cache',
+      });
+
+      const worker = createWorkerCacheManager(shared);
+      const action =
+        method === 'get'
+          ? worker.get('key')
+          : method === 'set'
+            ? worker.set('key', 'value')
+            : worker.delete('key');
+
+      await expect(action).rejects.toThrow('redis unavailable');
+      expect(worker.store).not.toBe(sharedStore);
+      expect(client.connect).not.toHaveBeenCalled();
+      expect(sharedStore.throwOnErrors).toBe(false);
+      expect(shared.throwOnErrors).toBe(false);
+    }
+  );
+});
+
+describe('createWorkerKVPostgresCleanup', () => {
+  it('gates the production cleanup to the PostgreSQL adapter type', () => {
+    const postgresStore = Object.setPrototypeOf(
+      new EventEmitter(),
+      KeyvPostgres.prototype
+    );
+    const redisStore = new KeyvRedis(
+      Object.assign(new EventEmitter(), {
+        isOpen: true,
+        connect: vi.fn(),
+      }) as any
+    );
+
+    expect(isWorkerKVPostgresStore(postgresStore)).toBe(true);
+    expect(isWorkerKVPostgresStore(redisStore)).toBe(false);
+    expect(isWorkerKVPostgresStore(new Map())).toBe(false);
+  });
+
+  it('reports the original PostgreSQL adapter after a successful Worker operation', async () => {
+    const postgresStore = Object.setPrototypeOf(
+      new EventEmitter(),
+      KeyvPostgres.prototype
+    ) as KeyvPostgres;
+    postgresStore.ttlSupport = false;
+    postgresStore.opts = {
+      dialect: 'postgres',
+      uri: 'postgresql://adapter-boundary',
+      schema: 'cache',
+      table: 'cache',
+    };
+    postgresStore.query = vi.fn(async () => []);
+    const shared = new Keyv({
+      store: postgresStore,
+      namespace: 'tianji-cache',
+    });
+    const maintenance = vi.fn();
+    const worker = createWorkerCacheManager(shared, maintenance);
+
+    await worker.set('worker-key', 'value');
+
+    expect(maintenance).toHaveBeenCalledWith(postgresStore);
+    expect(isWorkerKVPostgresStore(maintenance.mock.calls[0][0])).toBe(true);
+  });
+
+  it('gates PostgreSQL and issues a bounded prefix-restricted expiry delete', async () => {
+    const postgresStore = {};
+    const execute = vi.fn(async (_query: unknown) => 3);
+    const cleanup = createWorkerKVPostgresCleanup({
+      isPostgresStore: (store) => store === postgresStore,
+      execute,
+      now: () => 1_765_843_200_000,
+      intervalMs: 60_000,
+      batchSize: 100,
+      warn: vi.fn(),
+    });
+
+    await cleanup({});
+    expect(execute).not.toHaveBeenCalled();
+
+    await cleanup(postgresStore);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const query = execute.mock.calls[0][0] as {
+      strings: readonly string[];
+      values: readonly unknown[];
+    };
+    const sql = query.strings.join('?').replace(/\s+/g, ' ').trim();
+
+    expect(sql).toContain('DELETE FROM "cache"."cache"');
+    expect(sql).toContain(
+      'WHERE ( "key" LIKE ? OR "key" LIKE ? OR "key" LIKE ? )'
+    );
+    expect(sql).toContain(
+      "WHEN jsonb_typeof(\"value\"::jsonb -> 'expires') = 'number'"
+    );
+    expect(sql).toContain(
+      'THEN ("value"::jsonb ->> \'expires\')::bigint < ?'
+    );
+    expect(sql).toContain('LIMIT ?');
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED');
+    expect(query.values).toEqual([
+      'tianji-cache:worker-kv:v1:%',
+      'tianji-cache:workspace-kv:v1:%',
+      'tianji-cache:worker-kv-test:v1:%',
+      1_765_843_200_000,
+      100,
+    ]);
+  });
+
+  it('rate limits attempts and shares one in-flight cleanup', async () => {
+    const postgresStore = {};
+    let currentTime = 10_000;
+    let resolveExecution: (() => void) | undefined;
+    const execute = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExecution = resolve;
+        })
+    );
+    const cleanup = createWorkerKVPostgresCleanup({
+      isPostgresStore: (store) => store === postgresStore,
+      execute,
+      now: () => currentTime,
+      intervalMs: 60_000,
+      batchSize: 100,
+      warn: vi.fn(),
+    });
+
+    const first = cleanup(postgresStore);
+    const concurrent = cleanup(postgresStore);
+
+    expect(concurrent).toBe(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+    resolveExecution?.();
+    await first;
+
+    currentTime += 59_999;
+    await cleanup(postgresStore);
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    currentTime += 1;
+    const next = cleanup(postgresStore);
+    expect(execute).toHaveBeenCalledTimes(2);
+    resolveExecution?.();
+    await next;
+  });
+
+  it('contains cleanup failures behind a stable generic warning', async () => {
+    const postgresStore = {};
+    const warn = vi.fn();
+    const cleanup = createWorkerKVPostgresCleanup({
+      isPostgresStore: (store) => store === postgresStore,
+      execute: vi.fn(async () => {
+        throw new Error('postgresql://user:secret@database.internal/tianji');
+      }),
+      now: () => 10_000,
+      intervalMs: 60_000,
+      batchSize: 100,
+      warn,
+    });
+
+    await expect(cleanup(postgresStore)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      '[Worker KV] PostgreSQL expiry cleanup failed'
+    );
+    expect(String(warn.mock.calls[0])).not.toContain('secret');
+    expect(String(warn.mock.calls[0])).not.toContain('database.internal');
+  });
+});

--- a/src/server/cache/worker.ts
+++ b/src/server/cache/worker.ts
@@ -1,0 +1,199 @@
+import { Prisma } from '@prisma/client';
+import Keyv, { type KeyvStoreAdapter } from 'keyv';
+import KeyvPostgres from '@keyv/postgres';
+import KeyvRedis from '@keyv/redis';
+import { prisma } from '../model/_client.js';
+import { logger } from '../utils/logger.js';
+
+export const WORKER_KV_KEYV_NAMESPACE = 'tianji-cache';
+export const WORKER_KV_POSTGRES_CLEANUP_INTERVAL_MS = 60_000;
+export const WORKER_KV_POSTGRES_CLEANUP_BATCH_SIZE = 100;
+
+const WORKER_KV_POSTGRES_PREFIXES = [
+  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv:v1:%`,
+  `${WORKER_KV_KEYV_NAMESPACE}:workspace-kv:v1:%`,
+  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv-test:v1:%`,
+] as const;
+const WORKER_KV_POSTGRES_CLEANUP_WARNING =
+  '[Worker KV] PostgreSQL expiry cleanup failed';
+
+export function isWorkerKVPostgresStore(store: unknown) {
+  return store instanceof KeyvPostgres;
+}
+
+type SuccessfulStoreOperation = (store: unknown) => void;
+
+class SharedKeyvStoreAdapter {
+  namespace?: string;
+
+  constructor(
+    private readonly operationStore: KeyvStoreAdapter | Map<unknown, unknown>,
+    private readonly sharedStore: KeyvStoreAdapter | Map<unknown, unknown>,
+    private readonly onSuccessfulStoreOperation: SuccessfulStoreOperation
+  ) {}
+
+  private reportSuccess() {
+    try {
+      this.onSuccessfulStoreOperation(this.sharedStore);
+    } catch {
+      // Maintenance must never change the result of a Worker cache operation.
+    }
+  }
+
+  async get(key: string) {
+    const value = await (this.operationStore as any).get(key);
+    this.reportSuccess();
+    return value;
+  }
+
+  async set(key: string, value: unknown, ttl?: number) {
+    const result = await (this.operationStore as any).set(key, value, ttl);
+    if (result !== false) {
+      this.reportSuccess();
+    }
+    return result;
+  }
+
+  async delete(key: string) {
+    const deleted = await (this.operationStore as any).delete(key);
+    this.reportSuccess();
+    return deleted;
+  }
+
+  async clear() {
+    await (this.operationStore as any).clear();
+    this.reportSuccess();
+  }
+}
+
+function createWorkerOperationStore(
+  sharedStore: KeyvStoreAdapter | Map<unknown, unknown>
+) {
+  if (!(sharedStore instanceof KeyvRedis)) {
+    return sharedStore;
+  }
+
+  return new KeyvRedis(sharedStore.client, {
+    namespace: sharedStore.namespace,
+    keyPrefixSeparator: sharedStore.keyPrefixSeparator,
+    clearBatchSize: sharedStore.clearBatchSize,
+    useUnlink: sharedStore.useUnlink,
+    noNamespaceAffectsAll: sharedStore.noNamespaceAffectsAll,
+    throwOnConnectError: true,
+    throwOnErrors: true,
+    connectionTimeout: sharedStore.connectionTimeout,
+  });
+}
+
+export function createWorkerCacheManager(
+  shared: Keyv,
+  onSuccessfulStoreOperation: SuccessfulStoreOperation = () => {}
+): Keyv {
+  const operationStore = createWorkerOperationStore(shared.store);
+  const store = new SharedKeyvStoreAdapter(
+    operationStore,
+    shared.store,
+    onSuccessfulStoreOperation
+  );
+
+  return new Keyv({
+    store,
+    ttl: shared.ttl,
+    namespace: shared.namespace,
+    serialize: shared.serialize,
+    deserialize: shared.deserialize,
+    useKeyPrefix: shared.useKeyPrefix,
+    throwOnErrors: true,
+  });
+}
+
+interface WorkerKVPostgresCleanupDependencies {
+  isPostgresStore: (store: unknown) => boolean;
+  execute: (query: Prisma.Sql) => Promise<unknown>;
+  now: () => number;
+  intervalMs: number;
+  batchSize: number;
+  warn: (message: string) => void;
+}
+
+export function createWorkerKVPostgresCleanup(
+  dependencies: WorkerKVPostgresCleanupDependencies
+) {
+  let inFlight: Promise<void> | undefined;
+  let nextAllowedAt = Number.NEGATIVE_INFINITY;
+
+  return (store: unknown): Promise<void> => {
+    if (!dependencies.isPostgresStore(store)) {
+      return Promise.resolve();
+    }
+
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const now = dependencies.now();
+    if (now < nextAllowedAt) {
+      return Promise.resolve();
+    }
+    nextAllowedAt = now + dependencies.intervalMs;
+
+    const [privatePrefix, workspacePrefix, testPrefix] =
+      WORKER_KV_POSTGRES_PREFIXES;
+    const query = Prisma.sql`
+      WITH expired_worker_kv AS (
+        SELECT "key"
+        FROM "cache"."cache"
+        WHERE (
+          "key" LIKE ${privatePrefix}
+          OR "key" LIKE ${workspacePrefix}
+          OR "key" LIKE ${testPrefix}
+        )
+        AND CASE
+          WHEN jsonb_typeof("value"::jsonb -> 'expires') = 'number'
+          THEN ("value"::jsonb ->> 'expires')::bigint < ${now}
+          ELSE false
+        END
+        ORDER BY "key"
+        FOR UPDATE SKIP LOCKED
+        LIMIT ${dependencies.batchSize}
+      )
+      DELETE FROM "cache"."cache" AS target
+      USING expired_worker_kv AS expired
+      WHERE target."key" = expired."key"
+    `;
+
+    let execution: Promise<unknown>;
+    try {
+      execution = dependencies.execute(query);
+    } catch (error) {
+      execution = Promise.reject(error);
+    }
+
+    const cleanup = execution
+      .then(() => undefined)
+      .catch(() => {
+        dependencies.warn(WORKER_KV_POSTGRES_CLEANUP_WARNING);
+      })
+      .finally(() => {
+        if (inFlight === cleanup) {
+          inFlight = undefined;
+        }
+      });
+    inFlight = cleanup;
+
+    return cleanup;
+  };
+}
+
+const cleanupWorkerKVPostgres = createWorkerKVPostgresCleanup({
+  isPostgresStore: isWorkerKVPostgresStore,
+  execute: (query) => prisma.$executeRaw(query),
+  now: Date.now,
+  intervalMs: WORKER_KV_POSTGRES_CLEANUP_INTERVAL_MS,
+  batchSize: WORKER_KV_POSTGRES_CLEANUP_BATCH_SIZE,
+  warn: (message) => logger.warn(message),
+});
+
+export function scheduleWorkerKVPostgresCleanup(store: unknown) {
+  void cleanupWorkerKVPostgres(store);
+}

--- a/src/server/cache/worker.ts
+++ b/src/server/cache/worker.ts
@@ -10,9 +10,9 @@ export const WORKER_KV_POSTGRES_CLEANUP_INTERVAL_MS = 60_000;
 export const WORKER_KV_POSTGRES_CLEANUP_BATCH_SIZE = 100;
 
 const WORKER_KV_POSTGRES_PREFIXES = [
-  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv:v1:%`,
-  `${WORKER_KV_KEYV_NAMESPACE}:workspace-kv:v1:%`,
-  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv-test:v1:%`,
+  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv:v1:`,
+  `${WORKER_KV_KEYV_NAMESPACE}:workspace-kv:v1:`,
+  `${WORKER_KV_KEYV_NAMESPACE}:worker-kv-test:v1:`,
 ] as const;
 const WORKER_KV_POSTGRES_CLEANUP_WARNING =
   '[Worker KV] PostgreSQL expiry cleanup failed';
@@ -23,11 +23,18 @@ export function isWorkerKVPostgresStore(store: unknown) {
 
 type SuccessfulStoreOperation = (store: unknown) => void;
 
+interface WorkerOperationStore {
+  get(key: string): unknown;
+  set(key: string, value: unknown, ttl?: number): unknown;
+  delete(key: string): unknown;
+  clear(): unknown;
+}
+
 class SharedKeyvStoreAdapter {
   namespace?: string;
 
   constructor(
-    private readonly operationStore: KeyvStoreAdapter | Map<unknown, unknown>,
+    private readonly operationStore: WorkerOperationStore,
     private readonly sharedStore: KeyvStoreAdapter | Map<unknown, unknown>,
     private readonly onSuccessfulStoreOperation: SuccessfulStoreOperation
   ) {}
@@ -41,13 +48,13 @@ class SharedKeyvStoreAdapter {
   }
 
   async get(key: string) {
-    const value = await (this.operationStore as any).get(key);
+    const value = await this.operationStore.get(key);
     this.reportSuccess();
     return value;
   }
 
   async set(key: string, value: unknown, ttl?: number) {
-    const result = await (this.operationStore as any).set(key, value, ttl);
+    const result = await this.operationStore.set(key, value, ttl);
     if (result !== false) {
       this.reportSuccess();
     }
@@ -55,20 +62,77 @@ class SharedKeyvStoreAdapter {
   }
 
   async delete(key: string) {
-    const deleted = await (this.operationStore as any).delete(key);
+    const deleted = await this.operationStore.delete(key);
     this.reportSuccess();
     return deleted;
   }
 
   async clear() {
-    await (this.operationStore as any).clear();
+    await this.operationStore.clear();
     this.reportSuccess();
+  }
+}
+
+class WorkerMemoryStoreAdapter {
+  namespace?: string;
+  private readonly expiryTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
+  constructor(private readonly store: Map<unknown, unknown>) {}
+
+  async get(key: string) {
+    return this.store.get(key);
+  }
+
+  async set(key: string, value: unknown, ttl?: number) {
+    this.clearExpiryTimer(key);
+    this.store.set(key, value);
+
+    if (typeof ttl === 'number' && ttl > 0) {
+      const timer = setTimeout(() => {
+        if (this.store.get(key) === value) {
+          this.store.delete(key);
+        }
+        this.expiryTimers.delete(key);
+      }, ttl);
+      timer.unref?.();
+      this.expiryTimers.set(key, timer);
+    }
+
+    return true;
+  }
+
+  async delete(key: string) {
+    this.clearExpiryTimer(key);
+    return this.store.delete(key);
+  }
+
+  async clear() {
+    for (const timer of this.expiryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.expiryTimers.clear();
+    this.store.clear();
+  }
+
+  private clearExpiryTimer(key: string) {
+    const timer = this.expiryTimers.get(key);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.expiryTimers.delete(key);
+    }
   }
 }
 
 function createWorkerOperationStore(
   sharedStore: KeyvStoreAdapter | Map<unknown, unknown>
 ) {
+  if (sharedStore instanceof Map) {
+    return new WorkerMemoryStoreAdapter(sharedStore);
+  }
+
   if (!(sharedStore instanceof KeyvRedis)) {
     return sharedStore;
   }
@@ -121,6 +185,8 @@ export function createWorkerKVPostgresCleanup(
 ) {
   let inFlight: Promise<void> | undefined;
   let nextAllowedAt = Number.NEGATIVE_INFINITY;
+  let prefixIndex = 0;
+  const cursors = new Map<string, string>();
 
   return (store: unknown): Promise<void> => {
     if (!dependencies.isPostgresStore(store)) {
@@ -137,29 +203,33 @@ export function createWorkerKVPostgresCleanup(
     }
     nextAllowedAt = now + dependencies.intervalMs;
 
-    const [privatePrefix, workspacePrefix, testPrefix] =
-      WORKER_KV_POSTGRES_PREFIXES;
+    const prefix = WORKER_KV_POSTGRES_PREFIXES[prefixIndex];
+    const cursor = cursors.get(prefix) ?? prefix;
+    const prefixUpperBound = `${prefix}\uffff`;
     const query = Prisma.sql`
-      WITH expired_worker_kv AS (
-        SELECT "key"
+      WITH worker_kv_batch AS MATERIALIZED (
+        SELECT "key", "value"
         FROM "cache"."cache"
-        WHERE (
-          "key" LIKE ${privatePrefix}
-          OR "key" LIKE ${workspacePrefix}
-          OR "key" LIKE ${testPrefix}
-        )
-        AND CASE
-          WHEN jsonb_typeof("value"::jsonb -> 'expires') = 'number'
-          THEN ("value"::jsonb ->> 'expires')::bigint < ${now}
-          ELSE false
-        END
+        WHERE "key" > ${cursor}
+          AND "key" < ${prefixUpperBound}
         ORDER BY "key"
-        FOR UPDATE SKIP LOCKED
         LIMIT ${dependencies.batchSize}
+        FOR UPDATE SKIP LOCKED
+      ), deleted_worker_kv AS (
+        DELETE FROM "cache"."cache" AS target
+        USING worker_kv_batch AS candidate
+        WHERE target."key" = candidate."key"
+          AND CASE
+            WHEN jsonb_typeof(candidate."value"::jsonb -> 'expires') = 'number'
+            THEN (candidate."value"::jsonb ->> 'expires')::bigint < ${now}
+            ELSE false
+          END
+        RETURNING target."key"
       )
-      DELETE FROM "cache"."cache" AS target
-      USING expired_worker_kv AS expired
-      WHERE target."key" = expired."key"
+      SELECT
+        (SELECT "key" FROM worker_kv_batch ORDER BY "key" DESC LIMIT 1) AS "lastKey",
+        (SELECT COUNT(*)::int FROM worker_kv_batch) AS "scannedCount",
+        (SELECT COUNT(*)::int FROM deleted_worker_kv) AS "deletedCount"
     `;
 
     let execution: Promise<unknown>;
@@ -170,7 +240,22 @@ export function createWorkerKVPostgresCleanup(
     }
 
     const cleanup = execution
-      .then(() => undefined)
+      .then((result) => {
+        const row = Array.isArray(result) ? result[0] : undefined;
+        const lastKey =
+          row && typeof row.lastKey === 'string' ? row.lastKey : undefined;
+        const scannedCount =
+          row && typeof row.scannedCount !== 'undefined'
+            ? Number(row.scannedCount)
+            : 0;
+
+        if (lastKey !== undefined && scannedCount >= dependencies.batchSize) {
+          cursors.set(prefix, lastKey);
+        } else {
+          cursors.delete(prefix);
+          prefixIndex = (prefixIndex + 1) % WORKER_KV_POSTGRES_PREFIXES.length;
+        }
+      })
       .catch(() => {
         dependencies.warn(WORKER_KV_POSTGRES_CLEANUP_WARNING);
       })
@@ -187,7 +272,7 @@ export function createWorkerKVPostgresCleanup(
 
 const cleanupWorkerKVPostgres = createWorkerKVPostgresCleanup({
   isPostgresStore: isWorkerKVPostgresStore,
-  execute: (query) => prisma.$executeRaw(query),
+  execute: (query) => prisma.$queryRaw(query),
   now: Date.now,
   intervalMs: WORKER_KV_POSTGRES_CLEANUP_INTERVAL_MS,
   batchSize: WORKER_KV_POSTGRES_CLEANUP_BATCH_SIZE,

--- a/src/server/model/worker/index.spec.ts
+++ b/src/server/model/worker/index.spec.ts
@@ -109,8 +109,15 @@ describe('execWorker', () => {
 
     await execWorker(
       'async function fetch(params) { return { length: params.data.length }; }',
-      undefined,
-      largePayload
+      {
+        scope: {
+          kind: 'worker',
+          workspaceId: 'workspace-a',
+          workerId: 'worker-a',
+        },
+        requestPayload: largePayload,
+        context: { type: 'manual' },
+      }
     );
 
     const [source, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
@@ -216,8 +223,15 @@ describe('execWorker', () => {
 
     const execution = await execWorker(
       'async function fetch(params) { return params; }',
-      'worker_disabled',
-      requestPayload
+      {
+        scope: {
+          kind: 'worker',
+          workspaceId: 'workspace-a',
+          workerId: 'worker_disabled',
+        },
+        requestPayload,
+        context: { type: 'manual' },
+      }
     );
 
     const [, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
@@ -242,8 +256,15 @@ describe('execWorker', () => {
 
     const execution = await execWorker(
       'async function fetch(params) { return params; }',
-      'worker_enabled',
-      requestPayload
+      {
+        scope: {
+          kind: 'worker',
+          workspaceId: 'workspace-a',
+          workerId: 'worker_enabled',
+        },
+        requestPayload,
+        context: { type: 'manual' },
+      }
     );
 
     expect(execution.requestPayload).toBe(requestPayload);
@@ -260,8 +281,15 @@ describe('execWorker', () => {
 
     await execWorker(
       'async function fetch(params) { return params; }',
-      'worker_metrics',
-      requestPayload
+      {
+        scope: {
+          kind: 'worker',
+          workspaceId: 'workspace-a',
+          workerId: 'worker_metrics',
+        },
+        requestPayload,
+        context: { type: 'manual' },
+      }
     );
 
     expect(promWorkerMemoryUsageLabelsMock).toHaveBeenCalledWith(
@@ -275,6 +303,63 @@ describe('execWorker', () => {
     );
     expect(promWorkerRequestPayloadSizeObserveMock).toHaveBeenCalledWith(
       Buffer.byteLength(JSON.stringify(requestPayload), 'utf8')
+    );
+  });
+
+  test('installs KV globals without embedding worker scope identities in the VM source', async () => {
+    const workspaceId = 'workspace-source-secret';
+    const workerId = 'worker-source-secret';
+
+    await execWorker('async function fetch() { return true; }', {
+      scope: { kind: 'worker', workspaceId, workerId },
+      requestPayload: { event: 'manual' },
+      context: { type: 'manual' },
+    });
+
+    const [source, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
+
+    expect(source).toContain('globalThis.kv = Object.freeze(');
+    expect(source).not.toContain(workspaceId);
+    expect(source).not.toContain(workerId);
+    expect(globals).toEqual(
+      expect.objectContaining({
+        __workerKV: expect.anything(),
+        __workspaceKV: expect.anything(),
+      })
+    );
+  });
+
+  test('does not persist test scope executions and records anonymous metrics', async () => {
+    await execWorker('async function fetch() { return true; }', {
+      scope: {
+        kind: 'test',
+        workspaceId: 'workspace-a',
+        executionId: 'test-a',
+      },
+      requestPayload: { event: 'test' },
+      context: { type: 'manual' },
+    });
+
+    expect(enqueueMock).not.toHaveBeenCalled();
+    expect(promWorkerExecutionCounterLabelsMock).toHaveBeenCalledWith(
+      'anonymous',
+      'Success'
+    );
+    expect(promWorkerExecutionDurationLabelsMock).toHaveBeenCalledWith(
+      'anonymous',
+      'Success'
+    );
+    expect(promWorkerCPUTimeLabelsMock).toHaveBeenCalledWith(
+      'anonymous',
+      'Success'
+    );
+    expect(promWorkerMemoryUsageLabelsMock).toHaveBeenCalledWith(
+      'anonymous',
+      'Success'
+    );
+    expect(promWorkerRequestPayloadSizeLabelsMock).toHaveBeenCalledWith(
+      'anonymous',
+      'Success'
     );
   });
 });

--- a/src/server/model/worker/index.spec.ts
+++ b/src/server/model/worker/index.spec.ts
@@ -123,7 +123,6 @@ describe('execWorker', () => {
     const [source, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
 
     expect(source).not.toContain(largePayload.data);
-    expect(source.length).toBeLessThan(5_000);
     expect(globals).toEqual(
       expect.objectContaining({
         __requestPayload: largePayload,
@@ -134,10 +133,15 @@ describe('execWorker', () => {
   test('passes environment variables through context.env without embedding values in source', async () => {
     await execWorker(
       'async function fetch(payload, context) { return context.env.TOKEN; }',
-      undefined,
-      undefined,
-      { type: 'test' },
-      { TOKEN: 'runtime-secret' }
+      {
+        scope: {
+          kind: 'test',
+          workspaceId: 'workspace-a',
+          executionId: 'environment-test',
+        },
+        context: { type: 'test' },
+        environment: { TOKEN: 'runtime-secret' },
+      }
     );
 
     const [source, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
@@ -166,11 +170,16 @@ describe('execWorker', () => {
 
     const execution = await execWorker(
       'async function fetch() {}',
-      undefined,
-      undefined,
-      { type: 'test' },
-      { TOKEN: 'runtime-secret', LABEL: 'visible-text' },
-      ['runtime-secret']
+      {
+        scope: {
+          kind: 'test',
+          workspaceId: 'workspace-a',
+          executionId: 'redaction-test',
+        },
+        context: { type: 'test' },
+        environment: { TOKEN: 'runtime-secret', LABEL: 'visible-text' },
+        secretValues: ['runtime-secret'],
+      }
     );
 
     expect(execution.logs).toEqual([
@@ -182,6 +191,7 @@ describe('execWorker', () => {
   test('loads current environment on every stored execution', async () => {
     const storedWorker = {
       id: 'worker-stored',
+      workspaceId: 'workspace-a',
       code: 'async function fetch(payload, context) { return context.env.TOKEN; }',
     };
     loadWorkerEnvironmentForExecutionMock
@@ -306,7 +316,7 @@ describe('execWorker', () => {
     );
   });
 
-  test('installs KV globals without embedding worker scope identities in the VM source', async () => {
+  test('passes KV bridges without embedding worker scope identities in the VM source', async () => {
     const workspaceId = 'workspace-source-secret';
     const workerId = 'worker-source-secret';
 
@@ -318,7 +328,6 @@ describe('execWorker', () => {
 
     const [source, globals] = vi.mocked(runCodeInIVM).mock.calls[0];
 
-    expect(source).toContain('globalThis.kv = Object.freeze(');
     expect(source).not.toContain(workspaceId);
     expect(source).not.toContain(workerId);
     expect(globals).toEqual(

--- a/src/server/model/worker/index.ts
+++ b/src/server/model/worker/index.ts
@@ -17,6 +17,7 @@ import { env } from '../../utils/env.js';
 import {
   createWorkerKVFacade,
   type WorkerKVExecutionScope,
+  type WorkerKVScope,
 } from './kv.js';
 import { createSandboxProxy } from '../../utils/vm/sandbox.js';
 import { loadWorkerEnvironmentForExecution } from './environment.js';
@@ -93,6 +94,25 @@ export interface ExecWorkerOptions {
   secretValues?: string[];
 }
 
+function createWorkerKVBridge(scope: WorkerKVScope) {
+  return Object.assign(Object.create(null), {
+    get: scope.get,
+    set: async (key: string, encodedValue: unknown, ttl?: number) => {
+      let value: unknown;
+      if (typeof encodedValue === 'string') {
+        try {
+          value = JSON.parse(encodedValue);
+        } catch {
+          value = undefined;
+        }
+      }
+
+      return scope.set(key, value as never, ttl);
+    },
+    delete: scope.delete,
+  });
+}
+
 /**
  * execute a worker code in isolated-vm
  */
@@ -120,16 +140,10 @@ export async function execWorker(
     (left, right) => right.length - left.length
   );
   const kv = createWorkerKVFacade(options.scope);
-  const workerKVProxy = createSandboxProxy({
-    get: kv.get,
-    set: kv.set,
-    delete: kv.delete,
-  });
-  const workspaceKVProxy = createSandboxProxy({
-    get: kv.workspace.get,
-    set: kv.workspace.set,
-    delete: kv.workspace.delete,
-  });
+  const workerKVProxy = createSandboxProxy(createWorkerKVBridge(kv));
+  const workspaceKVProxy = createSandboxProxy(
+    createWorkerKVBridge(kv.workspace)
+  );
 
   try {
     const {
@@ -141,18 +155,233 @@ export async function execWorker(
       memoryUsage,
     } = await runCodeInIVM(`
       (async () => {
-        const __workerKVScope = reproxy(__workerKV);
-        const __workspaceKVScope = reproxy(__workspaceKV);
-        globalThis.kv = Object.freeze({
-          get: (...args) => __workerKVScope.get(...args),
-          set: (...args) => __workerKVScope.set(...args),
-          delete: (...args) => __workerKVScope.delete(...args),
-          workspace: __workspaceKVScope,
-        });
+        (() => {
+          const privateBridge = reproxy(globalThis.__workerKV);
+          const workspaceBridge = reproxy(globalThis.__workspaceKV);
+          delete globalThis.__workerKV;
+          delete globalThis.__workspaceKV;
 
-        ${code}
+          const objectCreate = Object.create;
+          const objectFreeze = Object.freeze;
+          const objectGetPrototypeOf = Object.getPrototypeOf;
+          const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+          const objectGetOwnPropertyNames = Object.getOwnPropertyNames;
+          const objectGetOwnPropertySymbols = Object.getOwnPropertySymbols;
+          const objectSetPrototypeOf = Object.setPrototypeOf;
+          const objectPrototype = Object.prototype;
+          const objectHasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+          const ErrorConstructor = Error;
+          const StringConstructor = String;
+          const ArrayConstructor = Array;
+          const arrayIsArray = Array.isArray;
+          const arrayPrototype = Array.prototype;
+          const NumberConstructor = Number;
+          const numberIsFinite = Number.isFinite;
+          const numberIsSafeInteger = Number.isSafeInteger;
+          const numberToString = Function.prototype.call.bind(Number.prototype.toString);
+          const jsonStringify = JSON.stringify;
+          const reflectApply = Reflect.apply;
+          const WeakSetConstructor = WeakSet;
+          const weakSetHas = Function.prototype.call.bind(WeakSet.prototype.has);
+          const weakSetAdd = Function.prototype.call.bind(WeakSet.prototype.add);
+          const weakSetDelete = Function.prototype.call.bind(WeakSet.prototype.delete);
+          const allowedErrorCodes = [
+            'WORKER_KV_INVALID_KEY',
+            'WORKER_KV_INVALID_VALUE',
+            'WORKER_KV_INVALID_TTL',
+            'WORKER_KV_LIMIT_EXCEEDED',
+            'WORKER_KV_TIMEOUT',
+            'WORKER_KV_UNAVAILABLE',
+          ];
 
-        return typeof fetch === 'function' ? fetch(__requestPayload, __workerContext) : 'fetch is not defined';
+          const sanitizeError = (error) => {
+            const message = error && typeof error.message === 'string'
+              ? error.message
+              : StringConstructor(error);
+            for (let index = 0; index < allowedErrorCodes.length; index += 1) {
+              const code = allowedErrorCodes[index];
+              if (message === code || message === 'Error: ' + code) {
+                return code;
+              }
+            }
+            return 'WORKER_KV_UNAVAILABLE';
+          };
+
+          const invoke = async (method, args) => {
+            try {
+              return await reflectApply(method, undefined, args);
+            } catch (error) {
+              const code = sanitizeError(error);
+              const sanitized = new ErrorConstructor(code);
+              sanitized.name = 'WorkerKVError';
+              sanitized.code = code;
+              throw sanitized;
+            }
+          };
+
+          const invalidValue = objectFreeze(objectCreate(null));
+
+          const hasSerializationHook = (prototype) => {
+            let current = prototype;
+            while (current !== null) {
+              if (objectGetOwnPropertyDescriptor(current, 'toJSON') !== undefined) {
+                return true;
+              }
+              current = objectGetPrototypeOf(current);
+            }
+            return false;
+          };
+
+          const isArrayIndex = (key, length) => {
+            const index = NumberConstructor(key);
+            return (
+              numberIsSafeInteger(index) &&
+              index >= 0 &&
+              index < length &&
+              numberToString(index) === key
+            );
+          };
+
+          const normalizeValue = (value, activePath) => {
+            if (
+              value === null ||
+              typeof value === 'string' ||
+              typeof value === 'boolean'
+            ) {
+              return value;
+            }
+            if (typeof value === 'number') {
+              return numberIsFinite(value) ? value : invalidValue;
+            }
+            if (typeof value !== 'object') {
+              return invalidValue;
+            }
+            if (weakSetHas(activePath, value)) {
+              return invalidValue;
+            }
+            weakSetAdd(activePath, value);
+
+            try {
+              if (objectGetOwnPropertySymbols(value).length > 0) {
+                return invalidValue;
+              }
+              if (arrayIsArray(value)) {
+                const prototype = objectGetPrototypeOf(value);
+                if (
+                  prototype !== arrayPrototype ||
+                  hasSerializationHook(prototype)
+                ) {
+                  return invalidValue;
+                }
+
+                const normalized = new ArrayConstructor(value.length);
+                objectSetPrototypeOf(normalized, null);
+                const propertyNames = objectGetOwnPropertyNames(value);
+                for (let index = 0; index < propertyNames.length; index += 1) {
+                  const key = propertyNames[index];
+                  if (key === 'length') {
+                    continue;
+                  }
+                  if (!isArrayIndex(key, value.length)) {
+                    return invalidValue;
+                  }
+
+                  const descriptor = objectGetOwnPropertyDescriptor(value, key);
+                  if (descriptor === undefined || !objectHasOwn(descriptor, 'value')) {
+                    return invalidValue;
+                  }
+                  const entry = normalizeValue(descriptor.value, activePath);
+                  if (entry === invalidValue) {
+                    return invalidValue;
+                  }
+                  normalized[NumberConstructor(key)] = entry;
+                }
+                return normalized;
+              }
+
+              const prototype = objectGetPrototypeOf(value);
+              if (
+                (prototype !== objectPrototype && prototype !== null) ||
+                hasSerializationHook(prototype)
+              ) {
+                return invalidValue;
+              }
+
+              const normalized = objectCreate(null);
+              const propertyNames = objectGetOwnPropertyNames(value);
+              for (let index = 0; index < propertyNames.length; index += 1) {
+                const key = propertyNames[index];
+                const descriptor = objectGetOwnPropertyDescriptor(value, key);
+                if (
+                  descriptor === undefined ||
+                  !descriptor.enumerable ||
+                  !objectHasOwn(descriptor, 'value')
+                ) {
+                  return invalidValue;
+                }
+
+                const entry = normalizeValue(descriptor.value, activePath);
+                if (entry === invalidValue) {
+                  return invalidValue;
+                }
+                normalized[key] = entry;
+              }
+              return normalized;
+            } catch {
+              return invalidValue;
+            } finally {
+              weakSetDelete(activePath, value);
+            }
+          };
+
+          const encodeValue = (value) => {
+            try {
+              const normalized = normalizeValue(value, new WeakSetConstructor());
+              if (normalized === invalidValue) {
+                return undefined;
+              }
+              const encoded = jsonStringify(normalized);
+              return typeof encoded === 'string' ? encoded : undefined;
+            } catch {
+              return undefined;
+            }
+          };
+
+          const createScope = (bridge) => {
+            const scope = objectCreate(null);
+            scope.get = (key) => invoke(
+              bridge.get,
+              [typeof key === 'string' ? key : '']
+            );
+            scope.set = (key, value, ttl) => invoke(
+              bridge.set,
+              [
+                typeof key === 'string' ? key : '',
+                encodeValue(value),
+                ttl === undefined || typeof ttl === 'number' ? ttl : 0,
+              ]
+            );
+            scope.delete = (key) => invoke(
+              bridge.delete,
+              [typeof key === 'string' ? key : '']
+            );
+            return objectFreeze(scope);
+          };
+
+          const privateScope = createScope(privateBridge);
+          const publicKV = objectCreate(null);
+          publicKV.get = privateScope.get;
+          publicKV.set = privateScope.set;
+          publicKV.delete = privateScope.delete;
+          publicKV.workspace = createScope(workspaceBridge);
+          globalThis.kv = objectFreeze(publicKV);
+        })();
+
+        return (async () => {
+          ${code}
+
+          return typeof fetch === 'function' ? fetch(__requestPayload, __workerContext) : 'fetch is not defined';
+        })();
       })()
     `, {
       __requestPayload: workerRequestPayload,

--- a/src/server/model/worker/index.ts
+++ b/src/server/model/worker/index.ts
@@ -16,6 +16,8 @@ import { createBatchWriter } from '../../utils/batchWriter.js';
 import { env } from '../../utils/env.js';
 import {
   createWorkerKVFacade,
+  WORKER_KV_MAX_KEY_LENGTH,
+  WORKER_KV_MAX_VALUE_BYTES,
   type WorkerKVExecutionScope,
   type WorkerKVScope,
 } from './kv.js';
@@ -179,6 +181,7 @@ export async function execWorker(
           const numberIsFinite = Number.isFinite;
           const numberIsSafeInteger = Number.isSafeInteger;
           const numberToString = Function.prototype.call.bind(Number.prototype.toString);
+          const stringCharCodeAt = Function.prototype.call.bind(String.prototype.charCodeAt);
           const jsonStringify = JSON.stringify;
           const reflectApply = Reflect.apply;
           const WeakSetConstructor = WeakSet;
@@ -341,29 +344,68 @@ export async function execWorker(
                 return undefined;
               }
               const encoded = jsonStringify(normalized);
-              return typeof encoded === 'string' ? encoded : undefined;
+              if (typeof encoded !== 'string') {
+                return undefined;
+              }
+
+              let encodedBytes = 0;
+              for (let index = 0; index < encoded.length; index += 1) {
+                const codeUnit = stringCharCodeAt(encoded, index);
+                if (codeUnit <= 0x7f) {
+                  encodedBytes += 1;
+                } else if (codeUnit <= 0x7ff) {
+                  encodedBytes += 2;
+                } else if (
+                  codeUnit >= 0xd800 &&
+                  codeUnit <= 0xdbff &&
+                  index + 1 < encoded.length
+                ) {
+                  const nextCodeUnit = stringCharCodeAt(encoded, index + 1);
+                  if (nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
+                    encodedBytes += 4;
+                    index += 1;
+                  } else {
+                    encodedBytes += 3;
+                  }
+                } else {
+                  encodedBytes += 3;
+                }
+
+                if (encodedBytes > ${WORKER_KV_MAX_VALUE_BYTES}) {
+                  return undefined;
+                }
+              }
+
+              return encoded;
             } catch {
               return undefined;
             }
           };
 
+          const encodeKey = (key) =>
+            typeof key === 'string' &&
+            key.length > 0 &&
+            key.length <= ${WORKER_KV_MAX_KEY_LENGTH}
+              ? key
+              : '';
+
           const createScope = (bridge) => {
             const scope = objectCreate(null);
             scope.get = (key) => invoke(
               bridge.get,
-              [typeof key === 'string' ? key : '']
+              [encodeKey(key)]
             );
             scope.set = (key, value, ttl) => invoke(
               bridge.set,
               [
-                typeof key === 'string' ? key : '',
+                encodeKey(key),
                 encodeValue(value),
                 ttl === undefined || typeof ttl === 'number' ? ttl : 0,
               ]
             );
             scope.delete = (key) => invoke(
               bridge.delete,
-              [typeof key === 'string' ? key : '']
+              [encodeKey(key)]
             );
             return objectFreeze(scope);
           };

--- a/src/server/model/worker/index.ts
+++ b/src/server/model/worker/index.ts
@@ -14,6 +14,11 @@ import {
 import { createId } from '@paralleldrive/cuid2';
 import { createBatchWriter } from '../../utils/batchWriter.js';
 import { env } from '../../utils/env.js';
+import {
+  createWorkerKVFacade,
+  type WorkerKVExecutionScope,
+} from './kv.js';
+import { createSandboxProxy } from '../../utils/vm/sandbox.js';
 import { loadWorkerEnvironmentForExecution } from './environment.js';
 
 const execRecordWriter = createBatchWriter<Prisma.FunctionWorkerExecutionCreateManyInput>({
@@ -80,30 +85,51 @@ export const { get: getWorker, del: delWorkerCache } = buildQueryWithCache(
   }
 );
 
+export interface ExecWorkerOptions {
+  scope: WorkerKVExecutionScope;
+  requestPayload?: Record<string, any>;
+  context?: Record<string, any>;
+  environment?: Record<string, string>;
+  secretValues?: string[];
+}
+
 /**
  * execute a worker code in isolated-vm
  */
 export async function execWorker(
   code: string,
-  workerId?: string,
-  requestPayload?: Record<string, any>,
-  context?: Record<string, any>,
-  environment: Record<string, string> = {},
-  secretValues: string[] = []
+  options: ExecWorkerOptions
 ) {
+  const workerId =
+    options.scope.kind === 'worker' ? options.scope.workerId : undefined;
+  const requestPayload = options.requestPayload;
+  const context = options.context;
   const workerRequestPayload: Record<string, any> = isPlainObject(requestPayload)
     ? (requestPayload as Record<string, any>)
     : {};
   const workerContext = {
     ...(isPlainObject(context) ? context : {}),
-    env: isPlainObject(environment) ? environment : {},
+    env: isPlainObject(options.environment) ? options.environment : {},
   };
   const shouldStoreRequestPayload = shouldStoreWorkerRequestPayload(workerId);
   const requestPayloadSizeBytes =
     getWorkerRequestPayloadSizeBytes(workerRequestPayload);
-  const secretsToRedact = [...new Set(secretValues.filter(Boolean))].sort(
+  const secretsToRedact = [
+    ...new Set((options.secretValues ?? []).filter(Boolean)),
+  ].sort(
     (left, right) => right.length - left.length
   );
+  const kv = createWorkerKVFacade(options.scope);
+  const workerKVProxy = createSandboxProxy({
+    get: kv.get,
+    set: kv.set,
+    delete: kv.delete,
+  });
+  const workspaceKVProxy = createSandboxProxy({
+    get: kv.workspace.get,
+    set: kv.workspace.set,
+    delete: kv.workspace.delete,
+  });
 
   try {
     const {
@@ -115,6 +141,15 @@ export async function execWorker(
       memoryUsage,
     } = await runCodeInIVM(`
       (async () => {
+        const __workerKVScope = reproxy(__workerKV);
+        const __workspaceKVScope = reproxy(__workspaceKV);
+        globalThis.kv = Object.freeze({
+          get: (...args) => __workerKVScope.get(...args),
+          set: (...args) => __workerKVScope.set(...args),
+          delete: (...args) => __workerKVScope.delete(...args),
+          workspace: __workspaceKVScope,
+        });
+
         ${code}
 
         return typeof fetch === 'function' ? fetch(__requestPayload, __workerContext) : 'fetch is not defined';
@@ -122,6 +157,8 @@ export async function execWorker(
     `, {
       __requestPayload: workerRequestPayload,
       __workerContext: workerContext,
+      __workerKV: workerKVProxy,
+      __workspaceKV: workspaceKVProxy,
     });
 
     const { used_heap_size } = memoryUsage;
@@ -207,19 +244,22 @@ export async function execWorker(
 }
 
 export async function execStoredWorker(
-  worker: { id: string; code: string },
+  worker: { id: string; workspaceId: string; code: string },
   requestPayload?: Record<string, any>,
   context?: Record<string, any>
 ) {
   const { environment, secretValues } =
     await loadWorkerEnvironmentForExecution(worker.id);
 
-  return execWorker(
-    worker.code,
-    worker.id,
+  return execWorker(worker.code, {
+    scope: {
+      kind: 'worker',
+      workspaceId: worker.workspaceId,
+      workerId: worker.id,
+    },
     requestPayload,
     context,
     environment,
-    secretValues
-  );
+    secretValues,
+  });
 }

--- a/src/server/model/worker/kv-ivm.spec.ts
+++ b/src/server/model/worker/kv-ivm.spec.ts
@@ -1,0 +1,367 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { env } from '../../utils/env.js';
+import { execWorker } from './index.js';
+
+let executionIndex = 0;
+
+async function executeKVWorker(code: string) {
+  executionIndex += 1;
+  return execWorker(code, {
+    scope: {
+      kind: 'test',
+      workspaceId: 'workspace-ivm',
+      executionId: `execution-${executionIndex}`,
+    },
+    requestPayload: {},
+    context: { type: 'test' },
+  });
+}
+
+describe('Worker KV isolated-vm bridge', () => {
+  beforeAll(() => {
+    env.cache.memoryOnly = true;
+    env.enableFunctionWorkerTypescriptSupport = false;
+  });
+
+  it('persists valid objects and repeated references through execWorker', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const shared = { count: 1 };
+        await kv.set('repeated', { first: shared, second: shared });
+        return kv.get('repeated');
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      first: { count: 1 },
+      second: { count: 1 },
+    });
+  });
+
+  it('keeps private and workspace bridges separate through execWorker', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        await kv.set('same-key', 'private');
+        await kv.workspace.set('same-key', 'workspace');
+        return {
+          privateValue: await kv.get('same-key'),
+          workspaceValue: await kv.workspace.get('same-key'),
+        };
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      privateValue: 'private',
+      workspaceValue: 'workspace',
+    });
+  });
+
+  it('rejects non-JSON isolate values with only the stable error code', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const cycle = {};
+        cycle.self = cycle;
+        class CustomValue {
+          constructor() {
+            this.count = 1;
+          }
+        }
+        const cases = [
+          ['function', { nested: () => 1 }],
+          ['class', new CustomValue()],
+          ['cycle', cycle],
+          ['symbol', { value: Symbol('invalid') }],
+          ['bigint', { count: 1n }],
+          ['non-finite', { count: Infinity }],
+          ['binary', new Uint8Array([1, 2, 3])],
+        ];
+        const results = [];
+
+        for (const [key, value] of cases) {
+          try {
+            await kv.set(key, value);
+            results.push('accepted');
+          } catch (error) {
+            results.push(String(error && error.message ? error.message : error));
+          }
+        }
+
+        return results;
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual([
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+    ]);
+  });
+
+  it('rejects own and inherited serialization hooks before encoding', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const results = [];
+        const hiddenHook = { original: true };
+        Object.defineProperty(hiddenHook, 'toJSON', {
+          value: () => ({ transformed: true }),
+        });
+
+        try {
+          await kv.set('own-hook', hiddenHook);
+          results.push('accepted');
+        } catch (error) {
+          results.push(error.message);
+        }
+
+        Object.defineProperty(Object.prototype, 'toJSON', {
+          configurable: true,
+          value: () => ({ transformed: true }),
+        });
+        try {
+          await kv.set('inherited-hook', { original: true });
+          results.push('accepted');
+        } catch (error) {
+          results.push(error.message);
+        } finally {
+          delete Object.prototype.toJSON;
+        }
+
+        return results;
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual([
+      'WORKER_KV_INVALID_VALUE',
+      'WORKER_KV_INVALID_VALUE',
+    ]);
+  });
+
+  it('counts rejected private and workspace values against one call budget', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const errors = [];
+        for (let index = 0; index < 51; index += 1) {
+          const scope = index % 2 === 0 ? kv : kv.workspace;
+          try {
+            await scope.set('invalid-' + index, { fn: () => index });
+            errors.push('accepted');
+          } catch (error) {
+            errors.push(String(error && error.message ? error.message : error));
+          }
+        }
+        return errors;
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual([
+      ...Array(50).fill('WORKER_KV_INVALID_VALUE'),
+      'WORKER_KV_LIMIT_EXCEEDED',
+    ]);
+  });
+
+  it('returns stable WorkerKVError fields without host or clone details', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        try {
+          await kv.set('invalid', { fn: () => true });
+          return { accepted: true };
+        } catch (error) {
+          return {
+            name: error.name,
+            code: error.code,
+            message: error.message,
+            stack: String(error.stack),
+          };
+        }
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual(
+      expect.objectContaining({
+        name: 'WorkerKVError',
+        code: 'WORKER_KV_INVALID_VALUE',
+        message: 'WORKER_KV_INVALID_VALUE',
+      })
+    );
+    expect((execution.responsePayload as any).stack).not.toContain(
+      'could not be cloned'
+    );
+    expect((execution.responsePayload as any).stack).not.toContain(
+      '/src/server/'
+    );
+  });
+
+  it('hides bridge globals and inherited methods from public KV scopes', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        return {
+          privateConstructor: typeof kv.constructor,
+          privateToString: typeof kv.toString,
+          workspaceConstructor: typeof kv.workspace.constructor,
+          workspaceToString: typeof kv.workspace.toString,
+          rawPrivate: typeof globalThis.__workerKV,
+          rawWorkspace: typeof globalThis.__workspaceKV,
+          lexicalPrivate: typeof __workerKVScope,
+          lexicalWorkspace: typeof __workspaceKVScope,
+          privateKeys: Object.keys(kv).sort(),
+          workspaceKeys: Object.keys(kv.workspace).sort(),
+        };
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      privateConstructor: 'undefined',
+      privateToString: 'undefined',
+      workspaceConstructor: 'undefined',
+      workspaceToString: 'undefined',
+      rawPrivate: 'undefined',
+      rawWorkspace: 'undefined',
+      lexicalPrivate: 'undefined',
+      lexicalWorkspace: 'undefined',
+      privateKeys: ['delete', 'get', 'set', 'workspace'],
+      workspaceKeys: ['delete', 'get', 'set'],
+    });
+  });
+
+  it('does not let hoisted worker declarations intercept bridge installation', async () => {
+    const execution = await executeKVWorker(`
+      const leaked = [];
+
+      function reproxy(reference) {
+        leaked.push(reference);
+        return new Proxy(reference, {
+          get(target, property, receiver) {
+            if (target !== reference || property === 'then') {
+              return Reflect.get(target, property, receiver);
+            }
+
+            const data = reference.get(property);
+            if (
+              typeof data === 'object' &&
+              data instanceof _ivm.Reference &&
+              data.typeof === 'function'
+            ) {
+              return (...args) => data.apply(undefined, args, {
+                arguments: { copy: true },
+                result: { promise: true },
+              });
+            }
+
+            return data;
+          },
+        });
+      }
+
+      async function fetch() {
+        return {
+          leakedCount: leaked.length,
+          rawPrivate: typeof globalThis.__workerKV,
+          missing: (await kv.get('missing')) === undefined,
+        };
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      leakedCount: 0,
+      rawPrivate: 'undefined',
+      missing: true,
+    });
+  });
+
+  it('installs KV before worker bindings shadow common globals', async () => {
+    const execution = await executeKVWorker(`
+      const globalThis = { worker: true };
+      const Object = { worker: true };
+      const Array = { worker: true };
+      const Number = { worker: true };
+      const JSON = { worker: true };
+      const WeakSet = { worker: true };
+      const Function = { worker: true };
+
+      async function fetch() {
+        await kv.set('shadowed', { accepted: true });
+        return {
+          value: await kv.get('shadowed'),
+          workerBindings: [
+            globalThis.worker,
+            Object.worker,
+            Array.worker,
+            Number.worker,
+            JSON.worker,
+            WeakSet.worker,
+            Function.worker,
+          ],
+        };
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      value: { accepted: true },
+      workerBindings: Array(7).fill(true),
+    });
+  });
+
+  it('uses captured intrinsics after worker code patches global behavior', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const originalIterator = Array.prototype[Symbol.iterator];
+        const OriginalError = globalThis.Error;
+        const OriginalString = globalThis.String;
+
+        Array.prototype[Symbol.iterator] = function* () {
+          yield 'poison';
+        };
+        globalThis.Error = function InjectedError() {
+          return { name: 'InjectedError', message: 'injected' };
+        };
+        globalThis.String = () => 'injected';
+
+        try {
+          await kv.set('stable-key', { accepted: true });
+          let invalid;
+          try {
+            await kv.set('invalid', { fn: () => true });
+          } catch (error) {
+            invalid = {
+              name: error.name,
+              code: error.code,
+              message: error.message,
+            };
+          }
+
+          return {
+            stored: await kv.get('stable-key'),
+            invalid,
+          };
+        } finally {
+          Array.prototype[Symbol.iterator] = originalIterator;
+          globalThis.Error = OriginalError;
+          globalThis.String = OriginalString;
+        }
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual({
+      stored: { accepted: true },
+      invalid: {
+        name: 'WorkerKVError',
+        code: 'WORKER_KV_INVALID_VALUE',
+        message: 'WORKER_KV_INVALID_VALUE',
+      },
+    });
+  });
+});

--- a/src/server/model/worker/kv-ivm.spec.ts
+++ b/src/server/model/worker/kv-ivm.spec.ts
@@ -201,6 +201,35 @@ describe('Worker KV isolated-vm bridge', () => {
     );
   });
 
+  it('replaces oversized keys and UTF-8 values before copying bridge arguments', async () => {
+    const execution = await executeKVWorker(`
+      async function fetch() {
+        const results = [];
+        try {
+          await kv.get('x'.repeat(257));
+          results.push('accepted-key');
+        } catch (error) {
+          results.push(error.message);
+        }
+
+        try {
+          await kv.set('large', '\u00e9'.repeat(131_072));
+          results.push('accepted-value');
+        } catch (error) {
+          results.push(error.message);
+        }
+
+        return results;
+      }
+    `);
+
+    expect(execution.error).toBeUndefined();
+    expect(execution.responsePayload).toEqual([
+      'WORKER_KV_INVALID_KEY',
+      'WORKER_KV_INVALID_VALUE',
+    ]);
+  });
+
   it('hides bridge globals and inherited methods from public KV scopes', async () => {
     const execution = await executeKVWorker(`
       async function fetch() {

--- a/src/server/model/worker/kv-keyv.spec.ts
+++ b/src/server/model/worker/kv-keyv.spec.ts
@@ -1,0 +1,102 @@
+import EventEmitter from 'node:events';
+import Keyv from 'keyv';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerCacheManager } from '../../cache/worker.js';
+
+const cacheModuleMocks = vi.hoisted(() => ({
+  getCacheManager: vi.fn(),
+  getWorkerCacheManager: vi.fn(),
+  scheduleWorkerKVPostgresCleanup: vi.fn(),
+}));
+
+vi.mock('../../cache/index.js', () => cacheModuleMocks);
+
+import { createWorkerKVFacade } from './kv.js';
+
+class RejectingAdapter extends EventEmitter {
+  namespace?: string;
+
+  async get() {
+    throw new Error('postgresql://user:secret@database.internal/tianji');
+  }
+
+  async set() {
+    throw new Error('postgresql://user:secret@database.internal/tianji');
+  }
+
+  async delete() {
+    throw new Error('postgresql://user:secret@database.internal/tianji');
+  }
+
+  async clear() {}
+}
+
+describe('Worker KV Keyv error boundary', () => {
+  beforeEach(() => {
+    const store = new RejectingAdapter();
+    const shared = new Keyv({
+      store,
+      namespace: 'tianji-cache',
+    });
+    const worker = createWorkerCacheManager(shared);
+
+    cacheModuleMocks.getCacheManager.mockResolvedValue(shared);
+    cacheModuleMocks.getWorkerCacheManager.mockResolvedValue(worker);
+    cacheModuleMocks.scheduleWorkerKVPostgresCleanup.mockReset();
+  });
+
+  it.each(['get', 'set', 'delete'] as const)(
+    'surfaces sanitized %s failures through a real Keyv instance',
+    async (method) => {
+      const kv = createWorkerKVFacade({
+        kind: 'worker',
+        workspaceId: 'workspace-a',
+        workerId: 'worker-a',
+      });
+      const action =
+        method === 'get'
+          ? kv.get('user-key')
+          : method === 'set'
+            ? kv.set('user-key', 'cached-value')
+            : kv.delete('user-key');
+
+      await expect(action).rejects.toMatchObject({
+        code: 'WORKER_KV_UNAVAILABLE',
+        message: 'WORKER_KV_UNAVAILABLE',
+      });
+      await action.catch((error: Error) => {
+        expect(String(error)).not.toContain('secret');
+        expect(String(error)).not.toContain('database.internal');
+        expect(String(error)).not.toContain('user-key');
+        expect(String(error)).not.toContain('cached-value');
+      });
+    }
+  );
+
+  it('fails closed when a real Keyv adapter returns false for a write', async () => {
+    const store = Object.assign(new EventEmitter(), {
+      namespace: undefined as string | undefined,
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => false),
+      delete: vi.fn(async () => false),
+      clear: vi.fn(async () => undefined),
+    });
+    const shared = new Keyv({
+      store,
+      namespace: 'tianji-cache',
+    });
+    cacheModuleMocks.getWorkerCacheManager.mockResolvedValue(
+      createWorkerCacheManager(shared)
+    );
+    const kv = createWorkerKVFacade({
+      kind: 'worker',
+      workspaceId: 'workspace-a',
+      workerId: 'worker-a',
+    });
+
+    await expect(kv.set('user-key', 'cached-value')).rejects.toMatchObject({
+      code: 'WORKER_KV_UNAVAILABLE',
+      message: 'WORKER_KV_UNAVAILABLE',
+    });
+  });
+});

--- a/src/server/model/worker/kv-postgres.spec.ts
+++ b/src/server/model/worker/kv-postgres.spec.ts
@@ -1,0 +1,107 @@
+import EventEmitter from 'node:events';
+import Keyv from 'keyv';
+import KeyvPostgres from '@keyv/postgres';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createWorkerKVFacade } from './kv.js';
+
+const postgresState = {
+  insertedRows: [] as Array<{ key: string; value: string }>,
+};
+
+describe('Worker KV PostgreSQL key boundary', () => {
+  beforeEach(() => {
+    postgresState.insertedRows = [];
+  });
+
+  it('stores maximum and NUL-containing logical keys within the schema-bound physical maximum', async () => {
+    const store = Object.setPrototypeOf(
+      new EventEmitter(),
+      KeyvPostgres.prototype
+    ) as KeyvPostgres;
+    store.ttlSupport = false;
+    store.opts = {
+      dialect: 'postgres',
+      uri: 'postgresql://adapter-boundary',
+      schema: 'cache',
+      table: 'cache',
+    };
+    store.query = async (sql: string, values: unknown[] = []) => {
+      if (sql.startsWith('INSERT INTO')) {
+        const key = String(values[0]);
+        if (key.length > 255) {
+          throw new Error('value too long for type character varying(255)');
+        }
+        if (key.includes('\0')) {
+          throw new Error('invalid byte sequence for encoding UTF8: 0x00');
+        }
+        postgresState.insertedRows.push({
+          key,
+          value: String(values[1]),
+        });
+      }
+
+      return [];
+    };
+    const cache = new Keyv({
+      store,
+      namespace: 'tianji-cache',
+      throwOnErrors: true,
+    });
+    const schemaMaximumId = 'c'.repeat(30);
+    const maximumKey = 'x'.repeat(256);
+    const worker = createWorkerKVFacade(
+      {
+        kind: 'worker',
+        workspaceId: schemaMaximumId,
+        workerId: schemaMaximumId,
+      },
+      { getCacheManager: async () => cache }
+    );
+    const testExecution = createWorkerKVFacade(
+      {
+        kind: 'test',
+        workspaceId: schemaMaximumId,
+        executionId: schemaMaximumId,
+      },
+      { getCacheManager: async () => cache }
+    );
+
+    await worker.set(maximumKey, 'private');
+    await worker.workspace.set(maximumKey, 'workspace');
+    await testExecution.set('nul\0key', 'test-private');
+    await testExecution.workspace.set(maximumKey, 'test-workspace');
+
+    const insertedKeys = postgresState.insertedRows.map(({ key }) => key);
+    expect(insertedKeys).toHaveLength(4);
+    expect(insertedKeys.every((key) => key.length < 255)).toBe(
+      true
+    );
+    expect(Math.max(...insertedKeys.map((key) => key.length))).toBe(167);
+    expect(insertedKeys.every((key) => !key.includes('\0'))).toBe(
+      true
+    );
+    expect(
+      insertedKeys.every((key) => !key.includes(maximumKey))
+    ).toBe(true);
+    expect(insertedKeys[0]).toMatch(/^tianji-cache:worker-kv:v1:/);
+    expect(insertedKeys[1]).toMatch(/^tianji-cache:workspace-kv:v1:/);
+    expect(insertedKeys[2]).toMatch(/^tianji-cache:worker-kv-test:v1:/);
+    expect(insertedKeys[3]).toMatch(/^tianji-cache:worker-kv-test:v1:/);
+
+    for (const { value } of postgresState.insertedRows) {
+      expect(JSON.parse(value)).toEqual(
+        expect.objectContaining({ expires: expect.any(Number) })
+      );
+    }
+
+    const suffixes = insertedKeys.map(
+      (key) => key.match(/[a-f0-9]{64}$/)?.[0]
+    );
+    expect(suffixes).toEqual([
+      '2fb07a8ca0613d2936869ab0871403b73145845360a040ff78e9153c17f82bea',
+      '2fb07a8ca0613d2936869ab0871403b73145845360a040ff78e9153c17f82bea',
+      '19fac380a8477018726e3b1f3a1c65709f4112cc3350b0702c3b625d2f0a653b',
+      '2fb07a8ca0613d2936869ab0871403b73145845360a040ff78e9153c17f82bea',
+    ]);
+  });
+});

--- a/src/server/model/worker/kv.spec.ts
+++ b/src/server/model/worker/kv.spec.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWorkerKVFacade } from './kv.js';
+
+function createCache() {
+  const values = new Map<string, unknown>();
+  return {
+    values,
+    cache: {
+      get: vi.fn(async (key: string) => values.get(key)),
+      set: vi.fn(async (key: string, value: unknown, ttl?: number) => {
+        values.set(key, value);
+        return true;
+      }),
+      delete: vi.fn(async (key: string) => values.delete(key)),
+    },
+  };
+}
+
+function createFacade(cache = createCache().cache) {
+  return createWorkerKVFacade(
+    { kind: 'worker', workspaceId: 'workspace-a', workerId: 'worker-a' },
+    { getCacheManager: async () => cache as any }
+  );
+}
+
+describe('createWorkerKVFacade', () => {
+  it('stores private and workspace values in isolated JSON namespaces', async () => {
+    const { cache } = createCache();
+    const kv = createFacade(cache);
+
+    await kv.set('state', { count: 1 });
+    expect(cache.set).toHaveBeenCalledWith(
+      'worker-kv:v1:workspace-a:worker-a:state',
+      JSON.stringify({ count: 1 }),
+      10 * 60 * 1000
+    );
+    expect(await kv.get('state')).toEqual({ count: 1 });
+
+    await kv.workspace.set('token', 'shared', 1_000);
+    expect(cache.set).toHaveBeenLastCalledWith(
+      'workspace-kv:v1:workspace-a:token',
+      JSON.stringify('shared'),
+      1_000
+    );
+  });
+
+  it('keeps private keys isolated by worker and workspace keys isolated by workspace', async () => {
+    const { cache } = createCache();
+    const first = createFacade(cache);
+    const secondWorker = createWorkerKVFacade(
+      { kind: 'worker', workspaceId: 'workspace-a', workerId: 'worker-b' },
+      { getCacheManager: async () => cache as any }
+    );
+    const secondWorkspace = createWorkerKVFacade(
+      { kind: 'worker', workspaceId: 'workspace-b', workerId: 'worker-a' },
+      { getCacheManager: async () => cache as any }
+    );
+
+    await first.set('state', 'private');
+    await first.workspace.set('shared', 'workspace-a');
+
+    expect(await secondWorker.get('state')).toBeUndefined();
+    expect(await secondWorkspace.workspace.get('shared')).toBeUndefined();
+  });
+
+  it('isolates both test scopes under their execution IDs', async () => {
+    const { cache } = createCache();
+    const first = createWorkerKVFacade(
+      { kind: 'test', workspaceId: 'workspace-a', executionId: 'execution-a' },
+      { getCacheManager: async () => cache as any }
+    );
+    const second = createWorkerKVFacade(
+      { kind: 'test', workspaceId: 'workspace-a', executionId: 'execution-b' },
+      { getCacheManager: async () => cache as any }
+    );
+
+    await first.set('state', 'private');
+    await first.workspace.set('shared', 'workspace');
+
+    expect(cache.set).toHaveBeenNthCalledWith(
+      1,
+      'worker-kv-test:v1:workspace-a:execution-a:private:state',
+      JSON.stringify('private'),
+      10 * 60 * 1000
+    );
+    expect(cache.set).toHaveBeenNthCalledWith(
+      2,
+      'worker-kv-test:v1:workspace-a:execution-a:workspace:shared',
+      JSON.stringify('workspace'),
+      10 * 60 * 1000
+    );
+    expect(await second.get('state')).toBeUndefined();
+    expect(await second.workspace.get('shared')).toBeUndefined();
+  });
+
+  it('returns latest writes, preserves falsy JSON values, and deletes values', async () => {
+    const kv = createFacade();
+
+    await kv.set('key', 'first');
+    await kv.set('key', 'second');
+    await kv.set('null', null);
+    await kv.set('false', false);
+    await kv.set('zero', 0);
+    await kv.set('empty', '');
+
+    expect(await kv.get('key')).toBe('second');
+    expect(await kv.get('null')).toBeNull();
+    expect(await kv.get('false')).toBe(false);
+    expect(await kv.get('zero')).toBe(0);
+    expect(await kv.get('empty')).toBe('');
+    expect(await kv.get('missing')).toBeUndefined();
+    expect(await kv.delete('key')).toBe(true);
+    expect(await kv.delete('key')).toBe(false);
+  });
+
+  it('rejects invalid keys, values, and TTLs with stable codes', async () => {
+    const kv = createFacade();
+
+    await expect(kv.get('')).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_KEY',
+    });
+    await expect(kv.get('x'.repeat(257))).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_KEY',
+    });
+    await expect(kv.set('key', Number.NaN)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_VALUE',
+    });
+    await expect(kv.set('key', new Date() as any)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_VALUE',
+    });
+    await expect(kv.set('key', 'value', 999)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_TTL',
+    });
+    await expect(kv.set('key', 'value', 86_400_001)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_TTL',
+    });
+  });
+
+  it('rejects cyclic and oversized values before writing them', async () => {
+    const { cache } = createCache();
+    const kv = createFacade(cache);
+    const cyclic: any = {};
+    cyclic.self = cyclic;
+
+    await expect(kv.set('cyclic', cyclic)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_VALUE',
+    });
+    await expect(kv.set('large', 'x'.repeat(256 * 1024))).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_VALUE',
+    });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('limits all private and workspace calls to one shared execution budget', async () => {
+    const kv = createFacade();
+
+    for (let index = 0; index < 49; index += 1) {
+      await kv.get(`key-${index}`);
+    }
+    await kv.workspace.get('last');
+    await expect(kv.get('overflow')).rejects.toMatchObject({
+      code: 'WORKER_KV_LIMIT_EXCEEDED',
+    });
+  });
+
+  it('counts rejected validation calls against the execution call budget', async () => {
+    const kv = createFacade();
+
+    await expect(kv.get('')).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_KEY',
+    });
+    for (let index = 0; index < 49; index += 1) {
+      await kv.get(`key-${index}`);
+    }
+    await expect(kv.get('overflow')).rejects.toMatchObject({
+      code: 'WORKER_KV_LIMIT_EXCEEDED',
+    });
+  });
+
+  it('limits total serialized writes for the whole execution', async () => {
+    const kv = createFacade();
+    const stringWithSerializedBytes = (bytes: number) => 'x'.repeat(bytes - 2);
+
+    for (let index = 0; index < 4; index += 1) {
+      await kv.set(`chunk-${index}`, stringWithSerializedBytes(256 * 1024));
+    }
+    await expect(kv.workspace.set('overflow', '')).rejects.toMatchObject({
+      code: 'WORKER_KV_LIMIT_EXCEEDED',
+    });
+  });
+
+  it('times out backend operations', async () => {
+    const cache = {
+      get: vi.fn(() => new Promise(() => undefined)),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
+    const kv = createWorkerKVFacade(
+      { kind: 'worker', workspaceId: 'workspace-a', workerId: 'worker-a' },
+      { getCacheManager: async () => cache as any, operationTimeoutMs: 10 }
+    );
+
+    await expect(kv.get('slow')).rejects.toMatchObject({
+      code: 'WORKER_KV_TIMEOUT',
+    });
+  });
+
+  it.each(['get', 'set', 'delete'] as const)(
+    'sanitizes backend %s failures',
+    async (method) => {
+      const secret = 'redis://user:secret@cache.internal';
+      const cache = {
+        get: vi.fn(async () => {
+          if (method === 'get') throw new Error(secret);
+          return undefined;
+        }),
+        set: vi.fn(async () => {
+          if (method === 'set') throw new Error(secret);
+          return true;
+        }),
+        delete: vi.fn(async () => {
+          if (method === 'delete') throw new Error(secret);
+          return false;
+        }),
+      };
+      const kv = createFacade(cache);
+      const action =
+        method === 'get'
+          ? kv.get('user-key')
+          : method === 'set'
+            ? kv.set('user-key', 'cached-value')
+            : kv.delete('user-key');
+
+      await expect(action).rejects.toMatchObject({
+        code: 'WORKER_KV_UNAVAILABLE',
+      });
+      await action.catch((error: Error) => {
+        expect(error.message).toBe('WORKER_KV_UNAVAILABLE');
+        expect(error.message).not.toContain('secret');
+        expect(error.message).not.toContain('cache.internal');
+        expect(error.message).not.toContain('user-key');
+        expect(error.message).not.toContain('cached-value');
+      });
+    }
+  );
+});

--- a/src/server/model/worker/kv.spec.ts
+++ b/src/server/model/worker/kv.spec.ts
@@ -30,7 +30,7 @@ describe('createWorkerKVFacade', () => {
 
     await kv.set('state', { count: 1 });
     expect(cache.set).toHaveBeenCalledWith(
-      'worker-kv:v1:workspace-a:worker-a:state',
+      'worker-kv:v1:workspace-a:worker-a:dad186f4c202034323be080a40febbd1f2655343ce274f085df8459ec8094dc6',
       JSON.stringify({ count: 1 }),
       10 * 60 * 1000
     );
@@ -38,7 +38,7 @@ describe('createWorkerKVFacade', () => {
 
     await kv.workspace.set('token', 'shared', 1_000);
     expect(cache.set).toHaveBeenLastCalledWith(
-      'workspace-kv:v1:workspace-a:token',
+      'workspace-kv:v1:workspace-a:68d7e994d91be4f25f36860f72027e3d9903d3d827faf143402b43b6df2e4e8b',
       JSON.stringify('shared'),
       1_000
     );
@@ -79,13 +79,13 @@ describe('createWorkerKVFacade', () => {
 
     expect(cache.set).toHaveBeenNthCalledWith(
       1,
-      'worker-kv-test:v1:workspace-a:execution-a:private:state',
+      'worker-kv-test:v1:workspace-a:execution-a:private:dad186f4c202034323be080a40febbd1f2655343ce274f085df8459ec8094dc6',
       JSON.stringify('private'),
       10 * 60 * 1000
     );
     expect(cache.set).toHaveBeenNthCalledWith(
       2,
-      'worker-kv-test:v1:workspace-a:execution-a:workspace:shared',
+      'worker-kv-test:v1:workspace-a:execution-a:workspace:f4a9c3550ea6fd37b8ac7f0c69ee5a5feda055548ccd392d26f0104cd32049f0',
       JSON.stringify('workspace'),
       10 * 60 * 1000
     );
@@ -122,18 +122,43 @@ describe('createWorkerKVFacade', () => {
     await expect(kv.get('x'.repeat(257))).rejects.toMatchObject({
       code: 'WORKER_KV_INVALID_KEY',
     });
-    await expect(kv.set('key', Number.NaN)).rejects.toMatchObject({
-      code: 'WORKER_KV_INVALID_VALUE',
-    });
-    await expect(kv.set('key', new Date() as any)).rejects.toMatchObject({
-      code: 'WORKER_KV_INVALID_VALUE',
-    });
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      undefined,
+      () => undefined,
+      Symbol('invalid'),
+      1n,
+      new Date(),
+      new Uint8Array([1, 2, 3]),
+      new (class CustomValue {
+        count = 1;
+      })(),
+    ];
+    for (const value of invalidValues) {
+      await expect(kv.set('key', value as any)).rejects.toMatchObject({
+        code: 'WORKER_KV_INVALID_VALUE',
+      });
+    }
     await expect(kv.set('key', 'value', 999)).rejects.toMatchObject({
       code: 'WORKER_KV_INVALID_TTL',
     });
     await expect(kv.set('key', 'value', 86_400_001)).rejects.toMatchObject({
       code: 'WORKER_KV_INVALID_TTL',
     });
+  });
+
+  it('accepts the exact minimum and maximum TTL boundaries', async () => {
+    const { cache } = createCache();
+    const kv = createFacade(cache);
+
+    await kv.set('minimum', 'value', 1_000);
+    await kv.workspace.set('maximum', 'value', 86_400_000);
+
+    expect(cache.set.mock.calls.map((call) => call[2])).toEqual([
+      1_000,
+      86_400_000,
+    ]);
   });
 
   it('rejects cyclic and oversized values before writing them', async () => {
@@ -149,6 +174,55 @@ describe('createWorkerKVFacade', () => {
       code: 'WORKER_KV_INVALID_VALUE',
     });
     expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('accepts repeated references that are not cyclic', async () => {
+    const kv = createFacade();
+    const shared = { count: 1 };
+
+    await kv.set('repeated', { first: shared, second: shared });
+
+    await expect(kv.get('repeated')).resolves.toEqual({
+      first: { count: 1 },
+      second: { count: 1 },
+    });
+  });
+
+  it('rejects hidden serialization hooks before they can transform a value', async () => {
+    const { cache } = createCache();
+    const kv = createFacade(cache);
+    const value = { original: true };
+    Object.defineProperty(value, 'toJSON', {
+      value: () => ({ transformed: true }),
+    });
+
+    await expect(kv.set('hidden-hook', value)).rejects.toMatchObject({
+      code: 'WORKER_KV_INVALID_VALUE',
+    });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('keeps distinct accepted UTF-16 key strings physically distinct', async () => {
+    const { cache } = createCache();
+    const kv = createFacade(cache);
+
+    await kv.set('\ud800', 'first');
+    await kv.set('\ud801', 'second');
+
+    expect(cache.set.mock.calls[0][0]).not.toBe(cache.set.mock.calls[1][0]);
+  });
+
+  it('treats a false backend write result as unavailable', async () => {
+    const cache = {
+      get: vi.fn(),
+      set: vi.fn(async () => false),
+      delete: vi.fn(),
+    };
+    const kv = createFacade(cache);
+
+    await expect(kv.set('key', 'value')).rejects.toMatchObject({
+      code: 'WORKER_KV_UNAVAILABLE',
+    });
   });
 
   it('limits all private and workspace calls to one shared execution budget', async () => {

--- a/src/server/model/worker/kv.ts
+++ b/src/server/model/worker/kv.ts
@@ -1,0 +1,229 @@
+import { getCacheManager } from '../../cache/index.js';
+
+export const WORKER_KV_DEFAULT_TTL_MS = 10 * 60 * 1000;
+export const WORKER_KV_MIN_TTL_MS = 1_000;
+export const WORKER_KV_MAX_TTL_MS = 24 * 60 * 60 * 1000;
+export const WORKER_KV_MAX_KEY_LENGTH = 256;
+export const WORKER_KV_MAX_VALUE_BYTES = 256 * 1024;
+export const WORKER_KV_MAX_CALLS = 50;
+export const WORKER_KV_MAX_WRITE_BYTES = 1024 * 1024;
+export const WORKER_KV_OPERATION_TIMEOUT_MS = 2_000;
+
+export type WorkerKVValue =
+  | null
+  | string
+  | number
+  | boolean
+  | WorkerKVValue[]
+  | { [key: string]: WorkerKVValue };
+
+export type WorkerKVExecutionScope =
+  | { kind: 'worker'; workspaceId: string; workerId: string }
+  | { kind: 'test'; workspaceId: string; executionId: string };
+
+export interface WorkerKVScope {
+  get<T extends WorkerKVValue = WorkerKVValue>(
+    key: string
+  ): Promise<T | undefined>;
+  set(key: string, value: WorkerKVValue, ttl?: number): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+export interface WorkerKVFacade extends WorkerKVScope {
+  workspace: WorkerKVScope;
+}
+
+export type WorkerKVErrorCode =
+  | 'WORKER_KV_INVALID_KEY'
+  | 'WORKER_KV_INVALID_VALUE'
+  | 'WORKER_KV_INVALID_TTL'
+  | 'WORKER_KV_LIMIT_EXCEEDED'
+  | 'WORKER_KV_TIMEOUT'
+  | 'WORKER_KV_UNAVAILABLE';
+
+export class WorkerKVError extends Error {
+  constructor(public readonly code: WorkerKVErrorCode) {
+    super(code);
+    this.name = 'WorkerKVError';
+  }
+}
+
+type WorkerKVDependencies = {
+  getCacheManager?: typeof getCacheManager;
+  operationTimeoutMs?: number;
+};
+
+function validateKey(key: string) {
+  if (
+    typeof key !== 'string' ||
+    key.length === 0 ||
+    key.length > WORKER_KV_MAX_KEY_LENGTH
+  ) {
+    throw new WorkerKVError('WORKER_KV_INVALID_KEY');
+  }
+}
+
+function validateValue(value: unknown, visited = new WeakSet<object>()): value is WorkerKVValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value !== 'object') {
+    return false;
+  }
+
+  if (visited.has(value)) {
+    return false;
+  }
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => validateValue(entry, visited));
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => validateValue(entry, visited));
+}
+
+function validateTtl(ttl: number | undefined) {
+  if (
+    ttl !== undefined &&
+    (!Number.isSafeInteger(ttl) ||
+      ttl < WORKER_KV_MIN_TTL_MS ||
+      ttl > WORKER_KV_MAX_TTL_MS)
+  ) {
+    throw new WorkerKVError('WORKER_KV_INVALID_TTL');
+  }
+}
+
+function encodeValue(value: WorkerKVValue) {
+  if (!validateValue(value)) {
+    throw new WorkerKVError('WORKER_KV_INVALID_VALUE');
+  }
+
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw new WorkerKVError('WORKER_KV_INVALID_VALUE');
+  }
+
+  if (Buffer.byteLength(encoded) > WORKER_KV_MAX_VALUE_BYTES) {
+    throw new WorkerKVError('WORKER_KV_INVALID_VALUE');
+  }
+
+  return encoded;
+}
+
+export function createWorkerKVFacade(
+  scope: WorkerKVExecutionScope,
+  dependencies: WorkerKVDependencies = {}
+): WorkerKVFacade {
+  const cacheManager = dependencies.getCacheManager ?? getCacheManager;
+  const operationTimeoutMs =
+    dependencies.operationTimeoutMs ?? WORKER_KV_OPERATION_TIMEOUT_MS;
+  const privatePrefix =
+    scope.kind === 'worker'
+      ? `worker-kv:v1:${scope.workspaceId}:${scope.workerId}:`
+      : `worker-kv-test:v1:${scope.workspaceId}:${scope.executionId}:private:`;
+  const workspacePrefix =
+    scope.kind === 'worker'
+      ? `workspace-kv:v1:${scope.workspaceId}:`
+      : `worker-kv-test:v1:${scope.workspaceId}:${scope.executionId}:workspace:`;
+  const budget = { calls: 0, writeBytes: 0 };
+
+  function consumeCall() {
+    budget.calls += 1;
+    if (budget.calls > WORKER_KV_MAX_CALLS) {
+      throw new WorkerKVError('WORKER_KV_LIMIT_EXCEEDED');
+    }
+  }
+
+  function consumeWrite(bytes: number) {
+    if (budget.writeBytes + bytes > WORKER_KV_MAX_WRITE_BYTES) {
+      throw new WorkerKVError('WORKER_KV_LIMIT_EXCEEDED');
+    }
+    budget.writeBytes += bytes;
+  }
+
+  async function runBackend<T>(operation: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new WorkerKVError('WORKER_KV_TIMEOUT')),
+            operationTimeoutMs
+          );
+        }),
+      ]);
+    } catch (error) {
+      if (error instanceof WorkerKVError) {
+        throw error;
+      }
+      throw new WorkerKVError('WORKER_KV_UNAVAILABLE');
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  function createScope(prefix: string): WorkerKVScope {
+    return {
+      async get<T extends WorkerKVValue = WorkerKVValue>(key: string) {
+        consumeCall();
+        validateKey(key);
+
+        const cache = await runBackend(cacheManager());
+        const cached = await runBackend(cache.get(`${prefix}${key}`));
+        if (cached === undefined) {
+          return undefined;
+        }
+
+        try {
+          return JSON.parse(String(cached)) as T;
+        } catch {
+          throw new WorkerKVError('WORKER_KV_UNAVAILABLE');
+        }
+      },
+
+      async set(key: string, value: WorkerKVValue, ttl?: number) {
+        consumeCall();
+        validateKey(key);
+        validateTtl(ttl);
+        const encoded = encodeValue(value);
+        consumeWrite(Buffer.byteLength(encoded));
+
+        const cache = await runBackend(cacheManager());
+        await runBackend(
+          cache.set(
+            `${prefix}${key}`,
+            encoded,
+            ttl ?? WORKER_KV_DEFAULT_TTL_MS
+          )
+        );
+      },
+
+      async delete(key: string) {
+        consumeCall();
+        validateKey(key);
+
+        const cache = await runBackend(cacheManager());
+        return runBackend(cache.delete(`${prefix}${key}`));
+      },
+    };
+  }
+
+  const privateScope = createScope(privatePrefix);
+  return { ...privateScope, workspace: createScope(workspacePrefix) };
+}

--- a/src/server/model/worker/kv.ts
+++ b/src/server/model/worker/kv.ts
@@ -1,4 +1,5 @@
-import { getCacheManager } from '../../cache/index.js';
+import { createHash } from 'node:crypto';
+import { getWorkerCacheManager } from '../../cache/index.js';
 
 export const WORKER_KV_DEFAULT_TTL_MS = 10 * 60 * 1000;
 export const WORKER_KV_MIN_TTL_MS = 1_000;
@@ -49,7 +50,7 @@ export class WorkerKVError extends Error {
 }
 
 type WorkerKVDependencies = {
-  getCacheManager?: typeof getCacheManager;
+  getCacheManager?: typeof getWorkerCacheManager;
   operationTimeoutMs?: number;
 };
 
@@ -63,34 +64,118 @@ function validateKey(key: string) {
   }
 }
 
-function validateValue(value: unknown, visited = new WeakSet<object>()): value is WorkerKVValue {
+const INVALID_WORKER_KV_VALUE = Symbol('INVALID_WORKER_KV_VALUE');
+
+function hasSerializationHook(prototype: object | null) {
+  let current = prototype;
+  while (current !== null) {
+    if (Object.getOwnPropertyDescriptor(current, 'toJSON') !== undefined) {
+      return true;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return false;
+}
+
+function isArrayIndex(key: string, length: number) {
+  const index = Number(key);
+  return (
+    Number.isSafeInteger(index) &&
+    index >= 0 &&
+    index < length &&
+    String(index) === key
+  );
+}
+
+function normalizeValue(
+  value: unknown,
+  activePath = new WeakSet<object>()
+): WorkerKVValue | typeof INVALID_WORKER_KV_VALUE {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-    return true;
+    return value;
   }
 
   if (typeof value === 'number') {
-    return Number.isFinite(value);
+    return Number.isFinite(value) ? value : INVALID_WORKER_KV_VALUE;
   }
 
   if (typeof value !== 'object') {
-    return false;
+    return INVALID_WORKER_KV_VALUE;
   }
 
-  if (visited.has(value)) {
-    return false;
+  if (activePath.has(value)) {
+    return INVALID_WORKER_KV_VALUE;
   }
-  visited.add(value);
+  activePath.add(value);
 
-  if (Array.isArray(value)) {
-    return value.every((entry) => validateValue(entry, visited));
+  try {
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      return INVALID_WORKER_KV_VALUE;
+    }
+
+    if (Array.isArray(value)) {
+      const prototype = Object.getPrototypeOf(value);
+      if (
+        prototype !== Array.prototype ||
+        hasSerializationHook(prototype)
+      ) {
+        return INVALID_WORKER_KV_VALUE;
+      }
+
+      const normalized: WorkerKVValue[] = new Array(value.length);
+      Object.setPrototypeOf(normalized, null);
+      for (const key of Object.getOwnPropertyNames(value)) {
+        if (key === 'length') {
+          continue;
+        }
+        if (!isArrayIndex(key, value.length)) {
+          return INVALID_WORKER_KV_VALUE;
+        }
+
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (descriptor === undefined || !Object.hasOwn(descriptor, 'value')) {
+          return INVALID_WORKER_KV_VALUE;
+        }
+        const entry = normalizeValue(descriptor.value, activePath);
+        if (entry === INVALID_WORKER_KV_VALUE) {
+          return INVALID_WORKER_KV_VALUE;
+        }
+        normalized[Number(key)] = entry;
+      }
+      return normalized;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (
+      (prototype !== Object.prototype && prototype !== null) ||
+      hasSerializationHook(prototype)
+    ) {
+      return INVALID_WORKER_KV_VALUE;
+    }
+
+    const normalized = Object.create(null) as Record<string, WorkerKVValue>;
+    for (const key of Object.getOwnPropertyNames(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        descriptor === undefined ||
+        !descriptor.enumerable ||
+        !Object.hasOwn(descriptor, 'value')
+      ) {
+        return INVALID_WORKER_KV_VALUE;
+      }
+
+      const entry = normalizeValue(descriptor.value, activePath);
+      if (entry === INVALID_WORKER_KV_VALUE) {
+        return INVALID_WORKER_KV_VALUE;
+      }
+      normalized[key] = entry;
+    }
+    return normalized;
+  } catch {
+    return INVALID_WORKER_KV_VALUE;
+  } finally {
+    activePath.delete(value);
   }
-
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
-    return false;
-  }
-
-  return Object.values(value).every((entry) => validateValue(entry, visited));
 }
 
 function validateTtl(ttl: number | undefined) {
@@ -105,13 +190,14 @@ function validateTtl(ttl: number | undefined) {
 }
 
 function encodeValue(value: WorkerKVValue) {
-  if (!validateValue(value)) {
+  const normalized = normalizeValue(value);
+  if (normalized === INVALID_WORKER_KV_VALUE) {
     throw new WorkerKVError('WORKER_KV_INVALID_VALUE');
   }
 
   let encoded: string;
   try {
-    encoded = JSON.stringify(value);
+    encoded = JSON.stringify(normalized);
   } catch {
     throw new WorkerKVError('WORKER_KV_INVALID_VALUE');
   }
@@ -123,11 +209,15 @@ function encodeValue(value: WorkerKVValue) {
   return encoded;
 }
 
+function encodeKey(key: string) {
+  return createHash('sha256').update(key, 'utf16le').digest('hex');
+}
+
 export function createWorkerKVFacade(
   scope: WorkerKVExecutionScope,
   dependencies: WorkerKVDependencies = {}
 ): WorkerKVFacade {
-  const cacheManager = dependencies.getCacheManager ?? getCacheManager;
+  const cacheManager = dependencies.getCacheManager ?? getWorkerCacheManager;
   const operationTimeoutMs =
     dependencies.operationTimeoutMs ?? WORKER_KV_OPERATION_TIMEOUT_MS;
   const privatePrefix =
@@ -185,7 +275,7 @@ export function createWorkerKVFacade(
         validateKey(key);
 
         const cache = await runBackend(cacheManager());
-        const cached = await runBackend(cache.get(`${prefix}${key}`));
+        const cached = await runBackend(cache.get(`${prefix}${encodeKey(key)}`));
         if (cached === undefined) {
           return undefined;
         }
@@ -205,13 +295,16 @@ export function createWorkerKVFacade(
         consumeWrite(Buffer.byteLength(encoded));
 
         const cache = await runBackend(cacheManager());
-        await runBackend(
+        const stored = await runBackend(
           cache.set(
-            `${prefix}${key}`,
+            `${prefix}${encodeKey(key)}`,
             encoded,
             ttl ?? WORKER_KV_DEFAULT_TTL_MS
           )
         );
+        if (stored === false) {
+          throw new WorkerKVError('WORKER_KV_UNAVAILABLE');
+        }
       },
 
       async delete(key: string) {
@@ -219,7 +312,7 @@ export function createWorkerKVFacade(
         validateKey(key);
 
         const cache = await runBackend(cacheManager());
-        return runBackend(cache.delete(`${prefix}${key}`));
+        return runBackend(cache.delete(`${prefix}${encodeKey(key)}`));
       },
     };
   }

--- a/src/server/router/__test__/worker.test.ts
+++ b/src/server/router/__test__/worker.test.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import supertest from 'supertest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execStoredWorker: vi.fn(),
+  getWorker: vi.fn(),
+}));
+
+vi.mock('../../model/worker/index.js', () => ({
+  execStoredWorker: mocks.execStoredWorker,
+  getWorker: mocks.getWorker,
+}));
+
+vi.mock('../../utils/env.js', () => ({
+  env: { enableFunctionWorker: true },
+}));
+
+import { workerRouter } from '../worker.js';
+
+const worker = {
+  id: 'worker-a',
+  workspaceId: 'workspace-a',
+  name: 'Worker A',
+  description: null,
+  code: 'async function fetch() { return { ok: true }; }',
+  revision: 1,
+  active: true,
+  enableCron: false,
+  cronExpression: null,
+  visibility: 'Public',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('workerRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getWorker.mockResolvedValue(worker);
+    mocks.execStoredWorker.mockResolvedValue({
+      responsePayload: { ok: true },
+    });
+  });
+
+  test('uses route identities for HTTP execution scope instead of payload identities', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(workerRouter);
+
+    const response = await supertest(app)
+      .post('/workspace-a/worker-a')
+      .send({
+        workspaceId: 'payload-workspace',
+        workerId: 'payload-worker',
+        value: 42,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(mocks.getWorker).toHaveBeenCalledWith('worker-a', 'workspace-a');
+    expect(mocks.execStoredWorker).toHaveBeenCalledWith(
+      worker,
+      expect.objectContaining({
+        workspaceId: 'payload-workspace',
+        workerId: 'payload-worker',
+      }),
+      expect.objectContaining({
+        type: 'http',
+      })
+    );
+  });
+});

--- a/src/server/router/worker.ts
+++ b/src/server/router/worker.ts
@@ -52,18 +52,14 @@ workerRouter.all(
       }
 
       // Execute the worker
-      const execution = await execStoredWorker(
-        worker,
-        requestPayload,
-        {
+      const execution = await execStoredWorker(worker, requestPayload, {
           type: 'http',
           request: {
             method: req.method,
             url: req.url,
             headers: { ...req.headers },
           },
-        }
-      );
+      });
 
       const response = execution.responsePayload;
 

--- a/src/server/trpc/routers/worker.spec.ts
+++ b/src/server/trpc/routers/worker.spec.ts
@@ -205,10 +205,30 @@ describe('workerRouter environment variables', () => {
 
     await caller.execute({ workspaceId, workerId: storedWorker.id, payload });
 
+    expect(mocks.findWorker).toHaveBeenCalledWith({
+      where: { id: storedWorker.id, workspaceId },
+    });
     expect(mocks.execStoredWorker).toHaveBeenCalledWith(storedWorker, payload, {
       type: 'manual',
     });
     expect(mocks.execWorker).not.toHaveBeenCalled();
+  });
+
+  test('denies manual execution when the worker belongs to another workspace', async () => {
+    const workspaceId = createId();
+    const workerId = createId();
+    mocks.findWorker.mockResolvedValue(null);
+    const caller = await createCaller();
+
+    await expect(
+      caller.execute({ workspaceId, workerId })
+    ).rejects.toThrow('Worker not found');
+
+    expect(mocks.findWorker).toHaveBeenCalledWith({
+      where: { id: workerId, workspaceId },
+    });
+    expect(mocks.execStoredWorker).not.toHaveBeenCalled();
+    expect(mocks.createAuditLog).not.toHaveBeenCalled();
   });
 
   test('resolves authorized saved and draft environment for test-code execution', async () => {

--- a/src/server/trpc/routers/worker.spec.ts
+++ b/src/server/trpc/routers/worker.spec.ts
@@ -241,12 +241,33 @@ describe('workerRouter environment variables', () => {
     );
     expect(mocks.execWorker).toHaveBeenCalledWith(
       storedWorker.code,
-      undefined,
-      undefined,
-      { type: 'test' },
-      { TOKEN: 'saved-secret' },
-      ['saved-secret']
+      {
+        scope: {
+          kind: 'test',
+          workspaceId,
+          executionId: expect.any(String),
+        },
+        requestPayload: undefined,
+        context: { type: 'test' },
+        environment: { TOKEN: 'saved-secret' },
+        secretValues: ['saved-secret'],
+      }
     );
+  });
+
+  test('creates a fresh workspace-scoped identity for every code test', async () => {
+    const workspaceId = createId();
+    const caller = await createCaller();
+
+    await caller.testCode({ workspaceId, code: 'return true;' });
+    await caller.testCode({ workspaceId, code: 'return true;' });
+
+    const firstScope = mocks.execWorker.mock.calls[0][1].scope;
+    const secondScope = mocks.execWorker.mock.calls[1][1].scope;
+    expect(firstScope).toMatchObject({ kind: 'test', workspaceId });
+    expect(firstScope.executionId).toEqual(expect.any(String));
+    expect(secondScope).toMatchObject({ kind: 'test', workspaceId });
+    expect(secondScope.executionId).not.toBe(firstScope.executionId);
   });
 
   test('does not resolve saved environment for a worker outside the workspace', async () => {

--- a/src/server/trpc/routers/worker.ts
+++ b/src/server/trpc/routers/worker.ts
@@ -27,6 +27,7 @@ import {
   resolveWorkerEnvironmentForExecution,
   workerEnvironmentVariablesInputSchema,
 } from '../../model/worker/environment.js';
+import { createId } from '@paralleldrive/cuid2';
 
 export const workerRouter = router({
   // Get all workers in workspace
@@ -677,14 +678,13 @@ export const workerRouter = router({
           workerId,
           environmentVariables
         );
-      const execution = await execWorker(
-        code,
-        undefined,
-        payload,
-        { type: 'test' },
+      const execution = await execWorker(code, {
+        scope: { kind: 'test', workspaceId, executionId: createId() },
+        requestPayload: payload,
+        context: { type: 'test' },
         environment,
-        secretValues
-      );
+        secretValues,
+      });
 
       return execution;
     }),

--- a/src/server/utils/vm/index.spec.ts
+++ b/src/server/utils/vm/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { runCodeInIVM } from './index.js';
+import { createSandboxProxy } from './sandbox.js';
 
 describe('runCodeInIVM', () => {
   test('should execute simple code and return result', async () => {
@@ -157,6 +158,33 @@ describe('runCodeInIVM', () => {
 
     expect(result.result).toBe(50_000);
     expect(result.error).toBeUndefined();
+  });
+
+  test('calls async methods through a sandbox proxy', async () => {
+    const host = createSandboxProxy({
+      get: async (key: string) => ({ key, value: 42 }),
+    });
+    const result = await runCodeInIVM(
+      `(async () => reproxy(__host).get('answer'))()`,
+      { __host: host }
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ key: 'answer', value: 42 });
+  });
+
+  test('propagates sanitized async proxy rejections', async () => {
+    const host = createSandboxProxy({
+      get: async () => {
+        throw new Error('WORKER_KV_UNAVAILABLE');
+      },
+    });
+    const result = await runCodeInIVM(
+      `(async () => reproxy(__host).get('answer'))()`,
+      { __host: host }
+    );
+
+    expect(String(result.error)).toContain('WORKER_KV_UNAVAILABLE');
   });
 
   test('should track execution time', async () => {

--- a/src/server/utils/vm/sandbox.ts
+++ b/src/server/utils/vm/sandbox.ts
@@ -33,7 +33,7 @@ function isTransferable(data: any): data is ivm.Transferable {
   );
 }
 
-function proxyObject(
+export function createSandboxProxy(
   obj: Record<string, any>,
   forbiddenKeys: string[] = []
 ): Record<string, any> {
@@ -83,7 +83,7 @@ export function copyObject(
   }
 
   if (obj instanceof Response) {
-    return proxyObject(obj, ['clone']);
+    return createSandboxProxy(obj, ['clone']);
   }
 
   if (isSemiTransferable(obj)) {


### PR DESCRIPTION
## Background
Workers need a small safe cache so one run can remember short-lived data and share it with other workers in the same workspace without exposing internal cache keys or backend clients.

## Changes
- Add a scoped Worker KV facade with private worker storage and explicit workspace storage.
- Inject `kv` and `kv.workspace` into the isolated worker sandbox with validation and sanitized errors.
- Add editor typings for the new KV API.
- Harden resource limits, key/value boundaries, TTLs, backend timeouts, and cache cleanup behavior.
- Enforce workspace-qualified worker lookup and per-test execution cache scopes.

## Testing
Patch adds focused Vitest coverage for KV facade behavior, isolated-vm bridge safety, cache adapters, PostgreSQL key boundaries and cleanup, worker router scope checks, TRPC execution scope, VM async host proxy, and editor sandbox declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure key-value storage API for workers, including private and workspace-scoped storage.
  * Added asynchronous `get`, `set`, and `delete` operations with optional expiration.
  * Added validation, size limits, timeouts, usage budgets, and sanitized error handling.
  * Added persistent cache support with automatic expiration cleanup.
* **Bug Fixes**
  * Improved workspace isolation and execution-scope handling for workers.
* **Tests**
  * Added comprehensive coverage for storage behavior, security boundaries, validation, expiration, failures, and sandbox integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->