### PR TITLE
feat(worker): add owner-based worker editing

### DIFF
--- a/src/client/components/UserSelect.component.spec.tsx
+++ b/src/client/components/UserSelect.component.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { UserSelect } from './UserSelect';
+
+describe('UserSelect', () => {
+  test('renders the selected user name and avatar fallback', async () => {
+    render(
+      <UserSelect
+        value="user123"
+        onValueChange={vi.fn()}
+        users={[
+          {
+            id: 'user123',
+            username: 'alice',
+            nickname: 'Alice Team',
+            avatar: null,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Alice Team');
+    expect(await screen.findByText('AL')).toBeInTheDocument();
+  });
+});

--- a/src/client/components/UserSelect.tsx
+++ b/src/client/components/UserSelect.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/utils/style';
+
+export interface UserSelectOption {
+  id: string;
+  username: string;
+  nickname?: string | null;
+  avatar?: string | null;
+}
+
+interface UserSelectProps {
+  users: UserSelectOption[];
+  value?: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function UserIdentity({ user }: { user: UserSelectOption }) {
+  const name = user.nickname ?? user.username;
+
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <Avatar className="h-6 w-6">
+        {user.avatar && <AvatarImage src={user.avatar} alt={name} />}
+        <AvatarFallback delayMs={user.avatar ? undefined : 0}>
+          {name.substring(0, 2).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+      <span className="truncate">{name}</span>
+    </span>
+  );
+}
+
+export const UserSelect: React.FC<UserSelectProps> = React.memo((props) => {
+  const selectedUser = useMemo(
+    () => props.users.find((user) => user.id === props.value),
+    [props.users, props.value]
+  );
+
+  return (
+    <Select
+      value={props.value}
+      onValueChange={props.onValueChange}
+      disabled={props.disabled}
+    >
+      <SelectTrigger className={cn('h-10', props.className)}>
+        <SelectValue placeholder={props.placeholder}>
+          {selectedUser && <UserIdentity user={selectedUser} />}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {props.users.map((user) => (
+          <SelectItem key={user.id} value={user.id}>
+            <UserIdentity user={user} />
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+});
+
+UserSelect.displayName = 'UserSelect';

--- a/src/client/components/worker/WorkerEditForm.component.spec.tsx
+++ b/src/client/components/worker/WorkerEditForm.component.spec.tsx
@@ -39,6 +39,17 @@ const mocks = vi.hoisted(() => ({
     createdAt: new Date('2026-08-15T00:00:00.000Z'),
     updatedAt: new Date('2026-08-15T00:00:00.000Z'),
   },
+  workspaceMembers: [
+    {
+      userId: 'userid123',
+      role: 'readOnly',
+      user: {
+        username: 'user',
+        nickname: 'Worker Owner',
+        avatar: 'https://example.com/avatar.png',
+      },
+    },
+  ],
 }));
 
 vi.mock('@i18next-toolkit/react', () => ({
@@ -80,11 +91,17 @@ vi.mock('@/api/trpc', () => ({
         }),
       },
     },
+    workspace: {
+      members: {
+        useQuery: () => ({ data: mocks.workspaceMembers }),
+      },
+    },
   },
 }));
 
 vi.mock('@/store/user', () => ({
   useCurrentWorkspaceId: () => 'workspace-a',
+  useHasAdminPermission: () => true,
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -352,6 +369,42 @@ describe('WorkerEditForm empty environment values', () => {
       });
     }
   );
+});
+
+describe('WorkerEditForm owner field', () => {
+  test('hides the owner field when creating a worker', () => {
+    render(
+      <WorkerEditForm
+        defaultValues={createDefaultValues('server-value')}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Owner')).not.toBeInTheDocument();
+  });
+
+  test('shows the owner field when editing a worker', () => {
+    render(
+      <WorkerEditForm
+        workerId="worker-a"
+        defaultValues={{
+          ...createDefaultValues('server-value'),
+          ownerId: 'userid123',
+        }}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const codeLabel = screen.getByText('JavaScript Code');
+    const ownerLabel = screen.getByText('Owner');
+
+    expect(ownerLabel).toBeInTheDocument();
+    expect(screen.getByText('Worker Owner')).toBeInTheDocument();
+    expect(
+      codeLabel.compareDocumentPosition(ownerLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });
 
 describe('Worker edit route cache refresh', () => {

--- a/src/client/components/worker/WorkerEditForm.tsx
+++ b/src/client/components/worker/WorkerEditForm.tsx
@@ -31,7 +31,10 @@ import {
 } from 'react-icons/lu';
 import { trpc } from '@/api/trpc';
 import { defaultErrorHandler } from '@/api/trpc';
-import { useCurrentWorkspaceId } from '@/store/user';
+import {
+  useCurrentWorkspaceId,
+  useHasAdminPermission,
+} from '@/store/user';
 import { WorkerExecutionDetail } from '@/components/worker/WorkerExecutionDetail';
 import {
   Dialog,
@@ -53,6 +56,7 @@ import {
   canMigrateLegacyWorkerCode,
   migrateLegacyWorkerCode,
 } from './workerCodeMigration';
+import { UserSelect } from '@/components/UserSelect';
 
 const environmentVariableKeySchema = z
   .string()
@@ -99,6 +103,7 @@ const formSchema = z
     enableCron: z.boolean().default(false),
     cronExpression: z.string().optional(),
     visibility: z.enum(['Public', 'Private']).default('Public'),
+    ownerId: z.cuid2().optional(),
     environmentVariables: z.array(environmentVariableSchema).superRefine(
       (items, ctx) => {
         const keys = new Set<string>();
@@ -149,6 +154,7 @@ export const WorkerEditForm: React.FC<WorkerEditFormProps> = React.memo(
   (props) => {
     const { t } = useTranslation();
     const workspaceId = useCurrentWorkspaceId();
+    const hasAdminPermission = useHasAdminPermission();
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [testResult, setTestResult] = useState<any>(null);
     const [showTestResult, setShowTestResult] = useState(false);
@@ -167,6 +173,10 @@ export const WorkerEditForm: React.FC<WorkerEditFormProps> = React.memo(
         ...props.defaultValues,
       }),
       [props.defaultValues]
+    );
+    const { data: workspaceMembers = [] } = trpc.workspace.members.useQuery(
+      { workspaceId },
+      { enabled: hasAdminPermission }
     );
     const form = useForm<WorkerEditFormValues>({
       resolver: zodResolver(formSchema),
@@ -366,6 +376,35 @@ export const WorkerEditForm: React.FC<WorkerEditFormProps> = React.memo(
                   </FormItem>
                 )}
               />
+
+              {hasAdminPermission && props.workerId && (
+                <FormField
+                  control={form.control}
+                  name="ownerId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('Owner')}</FormLabel>
+                      <UserSelect
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder={t('Select owner')}
+                        users={workspaceMembers.map((member) => ({
+                          id: member.userId,
+                          username: member.user.username,
+                          nickname: member.user.nickname,
+                          avatar: member.user.avatar,
+                        }))}
+                      />
+                      <FormDescription>
+                        {t(
+                          'The owner can edit this worker regardless of workspace role.'
+                        )}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               <FormField
                 control={form.control}

--- a/src/client/components/worker/WorkerRevisionsSection.tsx
+++ b/src/client/components/worker/WorkerRevisionsSection.tsx
@@ -25,16 +25,19 @@ import {
 } from 'react-icons/lu';
 import { SimpleTooltip } from '@/components/ui/tooltip';
 import dayjs from 'dayjs';
+import { UserIdentity } from '@/components/UserSelect';
 
 interface WorkerRevisionsSectionProps {
   workspaceId: string;
   workerId: string;
+  canEdit?: boolean;
   onRollback?: () => void;
 }
 
 export const WorkerRevisionsSection: React.FC<WorkerRevisionsSectionProps> = ({
   workspaceId,
   workerId,
+  canEdit = false,
   onRollback,
 }) => {
   const { t } = useTranslation();
@@ -200,10 +203,18 @@ export const WorkerRevisionsSection: React.FC<WorkerRevisionsSectionProps> = ({
                                 <Badge variant="outline">{t('Base')}</Badge>
                               )}
                             </div>
-                            <div className="text-muted-foreground text-xs">
-                              {createdAt.isValid()
-                                ? createdAt.format('YYYY-MM-DD HH:mm:ss')
-                                : ''}
+                            <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                              <span>
+                                {createdAt.isValid()
+                                  ? createdAt.format('YYYY-MM-DD HH:mm:ss')
+                                  : ''}
+                              </span>
+                              <span>·</span>
+                              {revision.operator ? (
+                                <UserIdentity user={revision.operator} />
+                              ) : (
+                                <span>{t('Unknown')}</span>
+                              )}
                             </div>
                           </div>
                           <div className="flex items-center gap-1">
@@ -227,7 +238,7 @@ export const WorkerRevisionsSection: React.FC<WorkerRevisionsSectionProps> = ({
                                 Icon={LuDiff}
                               />
                             </SimpleTooltip>
-                            {!isLatest && (
+                            {canEdit && !isLatest && (
                               <AlertConfirm
                                 title={t('Rollback to Revision #{{num}}', {
                                   num: revision.revision,

--- a/src/client/routes/worker/$workerId/edit.tsx
+++ b/src/client/routes/worker/$workerId/edit.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from '@i18next-toolkit/react';
-import { useCurrentWorkspaceId } from '@/store/user';
+import {
+  useCurrentWorkspaceId,
+  useHasAdminPermission,
+} from '@/store/user';
 import { CommonWrapper } from '@/components/CommonWrapper';
 import { routeAuthBeforeLoad } from '@/utils/route';
 import { CommonHeader } from '@/components/CommonHeader';
@@ -25,6 +28,7 @@ function PageComponent() {
   const { workerId } = Route.useParams<{ workerId: string }>();
   const { t } = useTranslation();
   const workspaceId = useCurrentWorkspaceId();
+  const hasAdminPermission = useHasAdminPermission();
   const navigate = useNavigate();
   const trpcUtils = trpc.useUtils();
   const workerQueryInput = { workspaceId, workerId };
@@ -54,8 +58,11 @@ function PageComponent() {
   const handleSubmit = useEvent(async (values: WorkerEditFormValues) => {
     if (!worker) return;
 
+    const { ownerId, ...workerValues } = values;
+
     await updateMutation.mutateAsync({
-      ...values,
+      ...workerValues,
+      ...(hasAdminPermission ? { ownerId } : {}),
       id: worker.id,
       workspaceId,
     });
@@ -90,6 +97,7 @@ function PageComponent() {
             enableCron: worker.enableCron || false,
             cronExpression: worker.cronExpression || '',
             visibility: worker.visibility || 'Public',
+            ownerId: worker.ownerId ?? undefined,
             environmentVariables,
           }}
           onSubmit={handleSubmit}

--- a/src/client/routes/worker/$workerId/index.tsx
+++ b/src/client/routes/worker/$workerId/index.tsx
@@ -2,7 +2,11 @@ import React, { Suspense, useState } from 'react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from '@i18next-toolkit/react';
 import { useEvent } from '@/hooks/useEvent';
-import { useCurrentWorkspaceId, useHasAdminPermission } from '@/store/user';
+import {
+  useCurrentWorkspaceId,
+  useHasAdminPermission,
+  useUserInfo,
+} from '@/store/user';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CommonWrapper } from '@/components/CommonWrapper';
 import { routeAuthBeforeLoad } from '@/utils/route';
@@ -63,6 +67,7 @@ function PageComponent() {
   const workspaceId = useCurrentWorkspaceId();
   const navigate = useNavigate();
   const hasAdminPermission = useHasAdminPermission();
+  const userId = useUserInfo()?.id;
   const [executionResult, setExecutionResult] = useState<any>(null);
   const [showExecutionResult, setShowExecutionResult] = useState(false);
   const [selectedExecutionIndex, setSelectedExecutionIndex] = useState(-1);
@@ -200,10 +205,13 @@ function PageComponent() {
     return <ErrorTip />;
   }
 
+  const canEdit = hasAdminPermission || worker.owner?.id === userId;
+
   return (
     <CommonWrapper
       header={
         <CommonHeader
+          desc={`${t('Creator')}: ${worker.creator?.nickname ?? worker.creator?.username ?? t('Unknown')} · ${t('Owner')}: ${worker.owner?.nickname ?? worker.owner?.username ?? t('Unknown')}`}
           title={
             <div className="flex items-center space-x-2">
               <span>{worker.name}</span>
@@ -223,7 +231,7 @@ function PageComponent() {
           }
           actions={
             <div className="flex items-center space-x-2">
-              {hasAdminPermission && (
+              {canEdit && (
                 <>
                   <Button
                     variant="outline"
@@ -252,16 +260,18 @@ function PageComponent() {
                     onClick={handleEdit}
                   />
 
-                  <AlertConfirm
-                    title={t('Delete Worker')}
-                    description={t(
-                      'Are you sure you want to delete this worker? This action cannot be undone.'
-                    )}
-                    onConfirm={handleDelete}
-                  >
-                    <Button variant="outline" size="icon" Icon={LuTrash} />
-                  </AlertConfirm>
                 </>
+              )}
+              {hasAdminPermission && (
+                <AlertConfirm
+                  title={t('Delete Worker')}
+                  description={t(
+                    'Are you sure you want to delete this worker? This action cannot be undone.'
+                  )}
+                  onConfirm={handleDelete}
+                >
+                  <Button variant="outline" size="icon" Icon={LuTrash} />
+                </AlertConfirm>
               )}
             </div>
           }
@@ -391,6 +401,7 @@ function PageComponent() {
             <WorkerRevisionsSection
               workspaceId={workspaceId}
               workerId={workerId}
+              canEdit={canEdit}
               onRollback={refetch}
             />
           </TabsContent>

--- a/src/client/routes/worker_/$workerId/editor.tsx
+++ b/src/client/routes/worker_/$workerId/editor.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from '@i18next-toolkit/react';
-import { useCurrentWorkspaceId, useHasAdminPermission } from '@/store/user';
+import {
+  useCurrentWorkspaceId,
+  useHasAdminPermission,
+  useUserInfo,
+} from '@/store/user';
 import { CommonWrapper } from '@/components/CommonWrapper';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -61,6 +65,7 @@ function PageComponent() {
   const workspaceId = useCurrentWorkspaceId();
   const navigate = useNavigate();
   const hasAdminPermission = useHasAdminPermission();
+  const userId = useUserInfo()?.id;
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedExecutionIndex, setSelectedExecutionIndex] =
@@ -138,9 +143,10 @@ function PageComponent() {
     () => canMigrateLegacyWorkerCode(code),
     [code]
   );
+  const canEdit = hasAdminPermission || worker?.owner?.id === userId;
 
   const handleSave = useEvent(async () => {
-    if (!worker || !hasAdminPermission || !isCodeDirty) {
+    if (!worker || !canEdit || !isCodeDirty) {
       return;
     }
 
@@ -269,13 +275,23 @@ function PageComponent() {
               </div>
 
               <div className="text-muted-foreground text-xs">
+                {t('Creator')}:{' '}
+                {worker.creator?.nickname ??
+                  worker.creator?.username ??
+                  t('Unknown')}
+                {' · '}
+                {t('Owner')}:{' '}
+                {worker.owner?.nickname ??
+                  worker.owner?.username ??
+                  t('Unknown')}
+                {' · '}
                 {t('Last updated at {{time}}', {
                   time: dayjs(worker.updatedAt).format('YYYY-MM-DD HH:mm:ss'),
                 })}
               </div>
             </div>
             <div className="flex items-center gap-2">
-              {hasAdminPermission && canMigrateWorkerCode && (
+              {canEdit && canMigrateWorkerCode && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -294,7 +310,7 @@ function PageComponent() {
               >
                 {t('Refresh')}
               </Button>
-              {hasAdminPermission && (
+              {canEdit && (
                 <Button
                   variant="default"
                   size="sm"
@@ -313,7 +329,7 @@ function PageComponent() {
         <Allotment>
           <Allotment.Pane>
             <CodeEditor
-              readOnly={!hasAdminPermission || updateMutation.isPending}
+              readOnly={!canEdit || updateMutation.isPending}
               height="100%"
               value={code}
               onChange={setCode}
@@ -352,7 +368,7 @@ function PageComponent() {
                   isActive={worker.active}
                   disabled={isCodeDirty}
                   onPreviewLoaded={handleLogRefresh}
-                  onTest={hasAdminPermission ? handleTestExecution : undefined}
+                  onTest={canEdit ? handleTestExecution : undefined}
                   variant="split"
                 />
               </Allotment.Pane>

--- a/src/server/model/worker/cronManager.spec.ts
+++ b/src/server/model/worker/cronManager.spec.ts
@@ -326,6 +326,7 @@ describe('WorkerCronManager lifecycle synchronization', () => {
     const result = await manager.upsert({
       ...upsertInput,
       id: 'worker-a',
+      operatorId: 'user-a',
     });
 
     expect(result).toBe(updatedWorker);
@@ -337,14 +338,43 @@ describe('WorkerCronManager lifecycle synchronization', () => {
     expect(manager.getRunner('worker-a')?.worker.code).toBe(
       'return "new";'
     );
+    expect(mocks.prisma.functionWorkerRevision.create).toHaveBeenCalledWith({
+      data: {
+        workerId: 'worker-a',
+        operatorId: 'user-a',
+        revision: 2,
+        code: 'return "new";',
+      },
+    });
   });
 
   test('successful create publishes the generated worker id', async () => {
     const manager = new WorkerCronManager();
     mocks.prisma.functionWorker.create.mockResolvedValue(updatedWorker);
 
-    await manager.upsert(upsertInput);
+    await manager.upsert({
+      ...upsertInput,
+      creatorId: 'user-a',
+      ownerId: 'user-b',
+      operatorId: 'user-a',
+    });
 
+    expect(mocks.prisma.functionWorker.create).toHaveBeenCalledWith({
+      data: {
+        ...upsertInput,
+        revision: 1,
+        creatorId: 'user-a',
+        ownerId: 'user-b',
+      },
+    });
+    expect(mocks.prisma.functionWorkerRevision.create).toHaveBeenCalledWith({
+      data: {
+        workerId: 'worker-a',
+        operatorId: 'user-a',
+        revision: 2,
+        code: 'return "new";',
+      },
+    });
     expect(mocks.workerCronBroadcast.publish).toHaveBeenCalledWith(
       'create',
       'workspace-a',

--- a/src/server/model/worker/cronManager.ts
+++ b/src/server/model/worker/cronManager.ts
@@ -17,6 +17,9 @@ export type WorkerCronUpsertData = Pick<
   'workspaceId' | 'name' | 'code' | 'enableCron' | 'cronExpression'
 > & {
   id?: string;
+  creatorId?: string;
+  ownerId?: string;
+  operatorId?: string;
   active?: boolean;
   description?: string;
   environmentVariables?: WorkerEnvironmentVariableInput[];
@@ -50,7 +53,14 @@ export class WorkerCronManager {
    * Create or update worker cron job
    */
   async upsert(data: WorkerCronUpsertData): Promise<FunctionWorker> {
-    const { id, workspaceId, environmentVariables, ...others } = data;
+    const {
+      id,
+      workspaceId,
+      creatorId,
+      operatorId,
+      environmentVariables,
+      ...others
+    } = data;
 
     if (id) {
       return this.runLifecycle(id, async () => {
@@ -98,6 +108,7 @@ export class WorkerCronManager {
             await tx.functionWorkerRevision.create({
               data: {
                 workerId: updatedWorker.id,
+                operatorId,
                 revision: updatedWorker.revision,
                 code: updatedWorker.code,
               },
@@ -119,12 +130,14 @@ export class WorkerCronManager {
           ...others,
           revision: 1,
           workspaceId,
+          creatorId,
         },
       });
 
       await tx.functionWorkerRevision.create({
         data: {
           workerId: createdWorker.id,
+          operatorId,
           revision: createdWorker.revision,
           code: createdWorker.code,
         },

--- a/src/server/prisma/migrations/20260817000000_add_function_worker_creator/migration.sql
+++ b/src/server/prisma/migrations/20260817000000_add_function_worker_creator/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "FunctionWorker"
+ADD COLUMN "creatorId" VARCHAR(30),
+ADD COLUMN "ownerId" VARCHAR(30);
+
+ALTER TABLE "FunctionWorkerRevision"
+ADD COLUMN "operatorId" VARCHAR(30);
+
+-- CreateIndex
+CREATE INDEX "FunctionWorker_creatorId_idx" ON "FunctionWorker"("creatorId");
+CREATE INDEX "FunctionWorker_ownerId_idx" ON "FunctionWorker"("ownerId");
+CREATE INDEX "FunctionWorkerRevision_operatorId_idx" ON "FunctionWorkerRevision"("operatorId");
+
+-- AddForeignKey
+ALTER TABLE "FunctionWorker" ADD CONSTRAINT "FunctionWorker_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "FunctionWorker" ADD CONSTRAINT "FunctionWorker_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "FunctionWorkerRevision" ADD CONSTRAINT "FunctionWorkerRevision_operatorId_fkey" FOREIGN KEY ("operatorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/server/prisma/schema.prisma
+++ b/src/server/prisma/schema.prisma
@@ -36,6 +36,9 @@ model User {
   workspaces          WorkspacesOnUsers[]
   apiKeys             UserApiKey[]
   workspaceInvitation WorkspaceInvitation[]
+  functionWorkersCreated FunctionWorker[] @relation("FunctionWorkerCreator")
+  functionWorkersOwned   FunctionWorker[] @relation("FunctionWorkerOwner")
+  functionWorkerRevisionsOperated FunctionWorkerRevision[] @relation("FunctionWorkerRevisionOperator")
 }
 
 model UserApiKey {
@@ -1146,6 +1149,8 @@ enum FunctionWorkerEnvironmentVariableType {
 model FunctionWorker {
   id             String                   @id @default(cuid()) @db.VarChar(30)
   workspaceId    String                   @db.VarChar(30)
+  creatorId      String?                  @db.VarChar(30)
+  ownerId        String?                  @db.VarChar(30)
   name           String
   description    String?
   code           String
@@ -1158,12 +1163,16 @@ model FunctionWorker {
   updatedAt      DateTime                 @updatedAt @db.Timestamptz(6)
 
   workspace Workspace @relation(fields: [workspaceId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  creator User? @relation("FunctionWorkerCreator", fields: [creatorId], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  owner   User? @relation("FunctionWorkerOwner", fields: [ownerId], references: [id], onUpdate: Cascade, onDelete: SetNull)
 
   executions FunctionWorkerExecution[]
   revisions  FunctionWorkerRevision[]
   environmentVariables FunctionWorkerEnvironmentVariable[]
 
   @@index([workspaceId])
+  @@index([creatorId])
+  @@index([ownerId])
 }
 
 model FunctionWorkerEnvironmentVariable {
@@ -1209,16 +1218,19 @@ model FunctionWorkerExecution {
 }
 
 model FunctionWorkerRevision {
-  id        String   @id @default(cuid()) @db.VarChar(30)
-  workerId  String   @db.VarChar(30)
-  revision  Int
-  code      String
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  id         String   @id @default(cuid()) @db.VarChar(30)
+  workerId   String   @db.VarChar(30)
+  operatorId String?  @db.VarChar(30)
+  revision   Int
+  code       String
+  createdAt  DateTime @default(now()) @db.Timestamptz(6)
 
-  worker FunctionWorker @relation(fields: [workerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  worker   FunctionWorker @relation(fields: [workerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  operator User?          @relation("FunctionWorkerRevisionOperator", fields: [operatorId], references: [id], onUpdate: Cascade, onDelete: SetNull)
 
   @@unique([workerId, revision])
   @@index([workerId, createdAt])
+  @@index([operatorId])
 }
 
 model WarehouseCohorts {

--- a/src/server/prisma/zod/functionworker.ts
+++ b/src/server/prisma/zod/functionworker.ts
@@ -1,11 +1,13 @@
 import * as z from "zod"
 import * as imports from "./schemas/index.js"
 import { FunctionWorkerVisibility } from "@prisma/client"
-import { CompleteWorkspace, RelatedWorkspaceModelSchema, CompleteFunctionWorkerExecution, RelatedFunctionWorkerExecutionModelSchema, CompleteFunctionWorkerRevision, RelatedFunctionWorkerRevisionModelSchema, CompleteFunctionWorkerEnvironmentVariable, RelatedFunctionWorkerEnvironmentVariableModelSchema } from "./index.js"
+import { CompleteWorkspace, RelatedWorkspaceModelSchema, CompleteUser, RelatedUserModelSchema, CompleteFunctionWorkerExecution, RelatedFunctionWorkerExecutionModelSchema, CompleteFunctionWorkerRevision, RelatedFunctionWorkerRevisionModelSchema, CompleteFunctionWorkerEnvironmentVariable, RelatedFunctionWorkerEnvironmentVariableModelSchema } from "./index.js"
 
 export const FunctionWorkerModelSchema = z.object({
   id: z.string(),
   workspaceId: z.string(),
+  creatorId: z.string().nullish(),
+  ownerId: z.string().nullish(),
   name: z.string(),
   description: z.string().nullish(),
   code: z.string(),
@@ -20,6 +22,8 @@ export const FunctionWorkerModelSchema = z.object({
 
 export interface CompleteFunctionWorker extends z.infer<typeof FunctionWorkerModelSchema> {
   workspace: CompleteWorkspace
+  creator?: CompleteUser | null
+  owner?: CompleteUser | null
   executions: CompleteFunctionWorkerExecution[]
   revisions: CompleteFunctionWorkerRevision[]
   environmentVariables: CompleteFunctionWorkerEnvironmentVariable[]
@@ -32,6 +36,8 @@ export interface CompleteFunctionWorker extends z.infer<typeof FunctionWorkerMod
  */
 export const RelatedFunctionWorkerModelSchema: z.ZodSchema<CompleteFunctionWorker> = z.lazy(() => FunctionWorkerModelSchema.extend({
   workspace: RelatedWorkspaceModelSchema,
+  creator: RelatedUserModelSchema.nullish(),
+  owner: RelatedUserModelSchema.nullish(),
   executions: RelatedFunctionWorkerExecutionModelSchema.array(),
   revisions: RelatedFunctionWorkerRevisionModelSchema.array(),
   environmentVariables: RelatedFunctionWorkerEnvironmentVariableModelSchema.array(),

--- a/src/server/prisma/zod/functionworkerrevision.ts
+++ b/src/server/prisma/zod/functionworkerrevision.ts
@@ -1,10 +1,11 @@
 import * as z from "zod"
 import * as imports from "./schemas/index.js"
-import { CompleteFunctionWorker, RelatedFunctionWorkerModelSchema } from "./index.js"
+import { CompleteFunctionWorker, RelatedFunctionWorkerModelSchema, CompleteUser, RelatedUserModelSchema } from "./index.js"
 
 export const FunctionWorkerRevisionModelSchema = z.object({
   id: z.string(),
   workerId: z.string(),
+  operatorId: z.string().nullish(),
   revision: z.number().int(),
   code: z.string(),
   createdAt: z.date(),
@@ -12,6 +13,7 @@ export const FunctionWorkerRevisionModelSchema = z.object({
 
 export interface CompleteFunctionWorkerRevision extends z.infer<typeof FunctionWorkerRevisionModelSchema> {
   worker: CompleteFunctionWorker
+  operator?: CompleteUser | null
 }
 
 /**
@@ -21,4 +23,5 @@ export interface CompleteFunctionWorkerRevision extends z.infer<typeof FunctionW
  */
 export const RelatedFunctionWorkerRevisionModelSchema: z.ZodSchema<CompleteFunctionWorkerRevision> = z.lazy(() => FunctionWorkerRevisionModelSchema.extend({
   worker: RelatedFunctionWorkerModelSchema,
+  operator: RelatedUserModelSchema.nullish(),
 }))

--- a/src/server/prisma/zod/user.ts
+++ b/src/server/prisma/zod/user.ts
@@ -1,6 +1,6 @@
 import * as z from "zod"
 import * as imports from "./schemas/index.js"
-import { CompleteAccount, RelatedAccountModelSchema, CompleteSession, RelatedSessionModelSchema, CompleteWorkspacesOnUsers, RelatedWorkspacesOnUsersModelSchema, CompleteUserApiKey, RelatedUserApiKeyModelSchema, CompleteWorkspaceInvitation, RelatedWorkspaceInvitationModelSchema } from "./index.js"
+import { CompleteAccount, RelatedAccountModelSchema, CompleteSession, RelatedSessionModelSchema, CompleteWorkspacesOnUsers, RelatedWorkspacesOnUsersModelSchema, CompleteUserApiKey, RelatedUserApiKeyModelSchema, CompleteWorkspaceInvitation, RelatedWorkspaceInvitationModelSchema, CompleteFunctionWorker, RelatedFunctionWorkerModelSchema, CompleteFunctionWorkerRevision, RelatedFunctionWorkerRevisionModelSchema } from "./index.js"
 
 export const UserModelSchema = z.object({
   id: z.string(),
@@ -23,6 +23,9 @@ export interface CompleteUser extends z.infer<typeof UserModelSchema> {
   workspaces: CompleteWorkspacesOnUsers[]
   apiKeys: CompleteUserApiKey[]
   workspaceInvitation: CompleteWorkspaceInvitation[]
+  functionWorkersCreated: CompleteFunctionWorker[]
+  functionWorkersOwned: CompleteFunctionWorker[]
+  functionWorkerRevisionsOperated: CompleteFunctionWorkerRevision[]
 }
 
 /**
@@ -36,4 +39,7 @@ export const RelatedUserModelSchema: z.ZodSchema<CompleteUser> = z.lazy(() => Us
   workspaces: RelatedWorkspacesOnUsersModelSchema.array(),
   apiKeys: RelatedUserApiKeyModelSchema.array(),
   workspaceInvitation: RelatedWorkspaceInvitationModelSchema.array(),
+  functionWorkersCreated: RelatedFunctionWorkerModelSchema.array(),
+  functionWorkersOwned: RelatedFunctionWorkerModelSchema.array(),
+  functionWorkerRevisionsOperated: RelatedFunctionWorkerRevisionModelSchema.array(),
 }))

--- a/src/server/trpc/routers/worker.spec.ts
+++ b/src/server/trpc/routers/worker.spec.ts
@@ -11,10 +11,14 @@ const mocks = vi.hoisted(() => {
       username: 'user',
       role: 'user',
     })),
-    getWorkspaceUser: vi.fn(async () => ({ role: 'owner' })),
+    getWorkspaceUser: vi.fn(
+      async (_workspaceId: string, _userId: string) => ({ role: 'owner' })
+    ),
     promStartTimer: vi.fn(() => endRequest),
     findWorker: vi.fn(),
+    findWorkers: vi.fn(),
     findEnvironmentVariables: vi.fn(),
+    findWorkerRevisions: vi.fn(),
     upsertWorker: vi.fn(),
     createAuditLog: vi.fn(),
     execWorker: vi.fn(),
@@ -45,9 +49,13 @@ vi.mock('../../model/_client.js', () => ({
   prisma: {
     functionWorker: {
       findUnique: mocks.findWorker,
+      findMany: mocks.findWorkers,
     },
     functionWorkerEnvironmentVariable: {
       findMany: mocks.findEnvironmentVariables,
+    },
+    functionWorkerRevision: {
+      findMany: mocks.findWorkerRevisions,
     },
   },
 }));
@@ -94,6 +102,8 @@ function worker(workspaceId: string, id = createId()) {
   return {
     id,
     workspaceId,
+    creatorId: null,
+    ownerId: null,
     name: 'Worker',
     description: null,
     code: 'return true;',
@@ -181,6 +191,9 @@ describe('workerRouter environment variables', () => {
 
     expect(mocks.upsertWorker).toHaveBeenCalledWith({
       id: undefined,
+      creatorId: 'user-id',
+      operatorId: 'user-id',
+      ownerId: 'user-id',
       workspaceId,
       name: savedWorker.name,
       description: undefined,
@@ -194,6 +207,214 @@ describe('workerRouter environment variables', () => {
       ],
     });
     expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  test('returns each revision with its operator identity', async () => {
+    const workspaceId = createId();
+    const workerId = createId();
+    const operatorId = createId();
+    const operator = {
+      id: operatorId,
+      username: 'operator',
+      nickname: 'Worker Operator',
+      avatar: 'https://example.com/operator.png',
+    };
+    mocks.findWorker.mockResolvedValue({ id: workerId });
+    mocks.findWorkerRevisions.mockResolvedValue([
+      {
+        id: createId(),
+        workerId,
+        operatorId,
+        revision: 1,
+        code: 'return true;',
+        createdAt: new Date('2026-08-17T00:00:00.000Z'),
+        operator,
+      },
+    ]);
+    const caller = await createCaller();
+
+    const result = await caller.getRevisions({ workspaceId, workerId });
+
+    expect(result[0]?.operator).toEqual(operator);
+    expect(mocks.findWorkerRevisions).toHaveBeenCalledWith({
+      where: { workerId },
+      include: {
+        operator: {
+          select: {
+            id: true,
+            username: true,
+            nickname: true,
+            avatar: true,
+          },
+        },
+      },
+      orderBy: { revision: 'desc' },
+    });
+  });
+
+  test('returns creator and owner profiles for workspace worker queries', async () => {
+    const workspaceId = createId();
+    const savedWorker = worker(workspaceId);
+    const creator = {
+      id: 'user-id',
+      username: 'user',
+      nickname: 'Maintainer',
+      avatar: null,
+    };
+    const owner = {
+      id: 'owner-id',
+      username: 'owner',
+      nickname: null,
+      avatar: null,
+    };
+    mocks.findWorker.mockResolvedValue({ ...savedWorker, creator, owner });
+    const caller = await createCaller();
+
+    const result = await caller.get({ workspaceId, workerId: savedWorker.id });
+
+    expect(result?.creator).toEqual(creator);
+    expect(result?.owner).toEqual(owner);
+    expect(mocks.findWorker).toHaveBeenCalledWith({
+      where: { id: savedWorker.id, workspaceId },
+      include: {
+        creator: {
+          select: {
+            id: true,
+            username: true,
+            nickname: true,
+            avatar: true,
+          },
+        },
+        owner: {
+          select: {
+            id: true,
+            username: true,
+            nickname: true,
+            avatar: true,
+          },
+        },
+      },
+    });
+  });
+
+  test('allows a readonly worker owner to update the worker', async () => {
+    const workspaceId = createId();
+    const savedWorker = {
+      ...worker(workspaceId),
+      ownerId: 'user-id',
+    };
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({ ownerId: 'user-id' });
+    mocks.upsertWorker.mockResolvedValue(savedWorker);
+    const caller = await createCaller();
+
+    await caller.upsert({
+      id: savedWorker.id,
+      workspaceId,
+      name: savedWorker.name,
+      code: savedWorker.code,
+    });
+
+    expect(mocks.upsertWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ id: savedWorker.id, ownerId: undefined })
+    );
+  });
+
+  test('denies a readonly non-owner from updating the worker', async () => {
+    const workspaceId = createId();
+    const savedWorker = worker(workspaceId);
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({ ownerId: 'another-user' });
+    const caller = await createCaller();
+
+    await expect(
+      caller.upsert({
+        id: savedWorker.id,
+        workspaceId,
+        name: savedWorker.name,
+        code: savedWorker.code,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mocks.upsertWorker).not.toHaveBeenCalled();
+  });
+
+  test('does not trust a requested ownerId when authorizing an update', async () => {
+    const workspaceId = createId();
+    const requestUserId = createId();
+    const savedWorker = worker(workspaceId);
+    mocks.jwtVerify.mockReturnValueOnce({
+      id: requestUserId,
+      username: 'user',
+      role: 'user',
+    });
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({ ownerId: 'another-user' });
+    const caller = await createCaller();
+
+    await expect(
+      caller.upsert({
+        id: savedWorker.id,
+        workspaceId,
+        ownerId: requestUserId,
+        name: savedWorker.name,
+        code: savedWorker.code,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mocks.upsertWorker).not.toHaveBeenCalled();
+  });
+
+  test('allows an admin to assign a readonly workspace member as owner', async () => {
+    const workspaceId = createId();
+    const readonlyUserId = createId();
+    const savedWorker = worker(workspaceId);
+    mocks.getWorkspaceUser.mockImplementation(async (_workspaceId, userId) =>
+      userId === readonlyUserId ? { role: 'readOnly' } : { role: 'admin' }
+    );
+    mocks.findWorker.mockResolvedValue({ ownerId: 'user-id' });
+    mocks.upsertWorker.mockResolvedValue({
+      ...savedWorker,
+      ownerId: readonlyUserId,
+    });
+    const caller = await createCaller();
+
+    await caller.upsert({
+      id: savedWorker.id,
+      workspaceId,
+      ownerId: readonlyUserId,
+      name: savedWorker.name,
+      code: savedWorker.code,
+    });
+
+    expect(mocks.getWorkspaceUser).toHaveBeenCalledWith(
+      workspaceId,
+      readonlyUserId
+    );
+    expect(mocks.upsertWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerId: readonlyUserId })
+    );
+  });
+
+  test('denies a readonly owner from transferring ownership', async () => {
+    const workspaceId = createId();
+    const nextOwnerId = createId();
+    const savedWorker = {
+      ...worker(workspaceId),
+      ownerId: 'user-id',
+    };
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({ ownerId: 'user-id' });
+    const caller = await createCaller();
+
+    await expect(
+      caller.upsert({
+        id: savedWorker.id,
+        workspaceId,
+        ownerId: nextOwnerId,
+        name: savedWorker.name,
+        code: savedWorker.code,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mocks.upsertWorker).not.toHaveBeenCalled();
   });
 
   test('executes a stored worker with fresh saved environment resolution', async () => {
@@ -237,7 +458,10 @@ describe('workerRouter environment variables', () => {
     const drafts = [
       { id: createId(), key: 'TOKEN', type: 'Secret' as const },
     ];
-    mocks.findWorker.mockResolvedValue({ id: storedWorker.id });
+    mocks.findWorker.mockResolvedValue({
+      id: storedWorker.id,
+      ownerId: 'user-id',
+    });
     mocks.resolveWorkerEnvironmentForExecution.mockResolvedValue({
       environment: { TOKEN: 'saved-secret' },
       secretValues: ['saved-secret'],
@@ -253,7 +477,7 @@ describe('workerRouter environment variables', () => {
 
     expect(mocks.findWorker).toHaveBeenCalledWith({
       where: { id: storedWorker.id, workspaceId },
-      select: { id: true },
+      select: { id: true, ownerId: true },
     });
     expect(mocks.resolveWorkerEnvironmentForExecution).toHaveBeenCalledWith(
       storedWorker.id,
@@ -273,6 +497,58 @@ describe('workerRouter environment variables', () => {
         secretValues: ['saved-secret'],
       }
     );
+  });
+
+  test('allows a readonly worker owner to test saved worker code', async () => {
+    const workspaceId = createId();
+    const storedWorker = worker(workspaceId);
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({
+      id: storedWorker.id,
+      ownerId: 'user-id',
+    });
+    const caller = await createCaller();
+
+    await caller.testCode({
+      workspaceId,
+      workerId: storedWorker.id,
+      code: storedWorker.code,
+    });
+
+    expect(mocks.execWorker).toHaveBeenCalledOnce();
+  });
+
+  test('denies a readonly non-owner from testing saved worker code', async () => {
+    const workspaceId = createId();
+    const storedWorker = worker(workspaceId);
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    mocks.findWorker.mockResolvedValue({
+      id: storedWorker.id,
+      ownerId: 'another-user',
+    });
+    const caller = await createCaller();
+
+    await expect(
+      caller.testCode({
+        workspaceId,
+        workerId: storedWorker.id,
+        code: storedWorker.code,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(mocks.execWorker).not.toHaveBeenCalled();
+  });
+
+  test('keeps draft code testing restricted to workspace admins', async () => {
+    const workspaceId = createId();
+    mocks.getWorkspaceUser.mockResolvedValue({ role: 'readOnly' });
+    const caller = await createCaller();
+
+    await expect(
+      caller.testCode({ workspaceId, code: 'return true;' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    expect(mocks.execWorker).not.toHaveBeenCalled();
   });
 
   test('creates a fresh workspace-scoped identity for every code test', async () => {

--- a/src/server/trpc/routers/worker.ts
+++ b/src/server/trpc/routers/worker.ts
@@ -28,6 +28,32 @@ import {
   workerEnvironmentVariablesInputSchema,
 } from '../../model/worker/environment.js';
 import { createId } from '@paralleldrive/cuid2';
+import { getWorkspaceUser } from '../../model/workspace.js';
+import { ROLES } from '@tianji/shared';
+
+const workerUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  nickname: z.string().nullable(),
+  avatar: z.string().nullable(),
+});
+
+const FunctionWorkerWithMaintainersSchema = FunctionWorkerModelSchema.extend({
+  creator: workerUserSchema.nullable(),
+  owner: workerUserSchema.nullable(),
+});
+
+const FunctionWorkerRevisionWithOperatorSchema =
+  FunctionWorkerRevisionModelSchema.extend({
+    operator: workerUserSchema.nullable(),
+  });
+
+const functionWorkerUserSelect = {
+  id: true,
+  username: true,
+  nickname: true,
+  avatar: true,
+} as const;
 
 export const workerRouter = router({
   // Get all workers in workspace
@@ -39,7 +65,7 @@ export const workerRouter = router({
         summary: 'Get all workers in workspace',
       })
     )
-    .output(z.array(FunctionWorkerModelSchema))
+    .output(z.array(FunctionWorkerWithMaintainersSchema))
     .query(async ({ input }) => {
       const { workspaceId } = input;
 
@@ -49,6 +75,10 @@ export const workerRouter = router({
         },
         orderBy: {
           updatedAt: 'desc',
+        },
+        include: {
+          creator: { select: functionWorkerUserSelect },
+          owner: { select: functionWorkerUserSelect },
         },
       });
 
@@ -69,7 +99,7 @@ export const workerRouter = router({
         workerId: z.cuid2(),
       })
     )
-    .output(FunctionWorkerModelSchema.nullable())
+    .output(FunctionWorkerWithMaintainersSchema.nullable())
     .query(async ({ input }) => {
       const { workerId, workspaceId } = input;
 
@@ -77,6 +107,10 @@ export const workerRouter = router({
         where: {
           id: workerId,
           workspaceId,
+        },
+        include: {
+          creator: { select: functionWorkerUserSelect },
+          owner: { select: functionWorkerUserSelect },
         },
       });
 
@@ -111,7 +145,7 @@ export const workerRouter = router({
     }),
 
   // Create or update worker
-  upsert: workspaceAdminProcedure
+  upsert: workspaceProcedure
     .meta(
       buildWorkerOpenapi({
         method: 'POST',
@@ -129,6 +163,7 @@ export const workerRouter = router({
         enableCron: z.boolean().default(false),
         cronExpression: z.string().optional(),
         environmentVariables: workerEnvironmentVariablesInputSchema.optional(),
+        ownerId: z.cuid2().optional(),
       })
     )
     .output(FunctionWorkerModelSchema)
@@ -142,8 +177,45 @@ export const workerRouter = router({
         enableCron,
         cronExpression,
         environmentVariables,
+        ownerId,
         workspaceId,
       } = input;
+
+      const workspaceUser = await getWorkspaceUser(workspaceId, ctx.user.id);
+      const hasAdminPermission = isWorkspaceAdmin(workspaceUser?.role);
+      let currentOwnerId: string | null = null;
+
+      if (id) {
+        const existingWorker = await prisma.functionWorker.findUnique({
+          where: { id, workspaceId },
+          select: { ownerId: true },
+        });
+
+        if (!existingWorker) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Worker not found' });
+        }
+
+        currentOwnerId = existingWorker.ownerId;
+        if (!hasAdminPermission && currentOwnerId !== ctx.user.id) {
+          throw new TRPCError({ code: 'FORBIDDEN' });
+        }
+      } else if (!hasAdminPermission) {
+        throw new TRPCError({ code: 'FORBIDDEN' });
+      }
+
+      if (ownerId !== undefined && ownerId !== currentOwnerId) {
+        if (!hasAdminPermission) {
+          throw new TRPCError({ code: 'FORBIDDEN' });
+        }
+
+        const ownerWorkspaceUser = await getWorkspaceUser(workspaceId, ownerId);
+        if (!ownerWorkspaceUser) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Worker owner must be a workspace member',
+          });
+        }
+      }
 
       // Validate cron expression if provided
       if (enableCron && cronExpression) {
@@ -185,6 +257,9 @@ export const workerRouter = router({
 
       const worker = await workerCronManager.upsert({
         id,
+        creatorId: id ? undefined : ctx.user.id,
+        operatorId: ctx.user.id,
+        ownerId: id ? ownerId : (ownerId ?? ctx.user.id),
         workspaceId,
         name,
         description,
@@ -251,7 +326,7 @@ export const workerRouter = router({
     }),
 
   // Toggle worker active status
-  toggleActive: workspaceAdminProcedure
+  toggleActive: workspaceProcedure
     .meta(
       buildWorkerOpenapi({
         method: 'PATCH',
@@ -280,9 +355,12 @@ export const workerRouter = router({
         throw new Error('Worker not found');
       }
 
+      await assertCanEditWorker(workspaceId, ctx.user.id, worker.ownerId);
+
       // Use workerCronManager.upsert to update both database and cron manager state
       const updatedWorker = await workerCronManager.upsert({
         id: workerId,
+        operatorId: ctx.user.id,
         workspaceId,
         name: worker.name,
         description: worker.description ?? undefined,
@@ -640,7 +718,7 @@ export const workerRouter = router({
         p99CpuTime: toNum(item.p99CpuTime),
       }));
     }),
-  testCode: workspaceAdminProcedure
+  testCode: workspaceProcedure
     .input(
       z.object({
         code: z.string(),
@@ -649,7 +727,7 @@ export const workerRouter = router({
         environmentVariables: workerEnvironmentVariablesInputSchema.optional(),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       const {
         code,
         payload = undefined,
@@ -665,12 +743,18 @@ export const workerRouter = router({
       if (workerId) {
         const worker = await prisma.functionWorker.findUnique({
           where: { id: workerId, workspaceId },
-          select: { id: true },
+          select: { id: true, ownerId: true },
         });
 
         if (!worker) {
           throw new Error('Worker not found');
         }
+
+        await assertCanEditWorker(workspaceId, ctx.user.id, worker.ownerId);
+      } else {
+        // Draft code is not associated with a worker owner, so testing it
+        // remains restricted to workspace administrators.
+        await assertCanEditWorker(workspaceId, ctx.user.id, null);
       }
 
       const { environment, secretValues } =
@@ -689,7 +773,7 @@ export const workerRouter = router({
       return execution;
     }),
 
-  rollbackToRevision: workspaceAdminProcedure
+  rollbackToRevision: workspaceProcedure
     .meta(
       buildWorkerOpenapi({
         method: 'POST',
@@ -718,6 +802,8 @@ export const workerRouter = router({
         throw new Error('Worker not found');
       }
 
+      await assertCanEditWorker(workspaceId, ctx.user.id, worker.ownerId);
+
       const revision = await prisma.functionWorkerRevision.findUnique({
         where: {
           id: revisionId,
@@ -735,6 +821,7 @@ export const workerRouter = router({
 
       const updatedWorker = await workerCronManager.upsert({
         id: workerId,
+        operatorId: ctx.user.id,
         workspaceId,
         name: worker.name,
         description: worker.description ?? undefined,
@@ -767,7 +854,7 @@ export const workerRouter = router({
         workerId: z.string().cuid2(),
       })
     )
-    .output(z.array(FunctionWorkerRevisionModelSchema))
+    .output(z.array(FunctionWorkerRevisionWithOperatorSchema))
     .query(async ({ input }) => {
       const { workerId, workspaceId } = input;
 
@@ -786,6 +873,9 @@ export const workerRouter = router({
         where: {
           workerId,
         },
+        include: {
+          operator: { select: functionWorkerUserSelect },
+        },
         orderBy: {
           revision: 'desc',
         },
@@ -794,6 +884,25 @@ export const workerRouter = router({
       return revisions;
     }),
 });
+
+function isWorkspaceAdmin(role?: string): boolean {
+  return role === ROLES.owner || role === ROLES.admin;
+}
+
+async function assertCanEditWorker(
+  workspaceId: string,
+  userId: string,
+  ownerId: string | null
+): Promise<void> {
+  if (ownerId === userId) {
+    return;
+  }
+
+  const workspaceUser = await getWorkspaceUser(workspaceId, userId);
+  if (!isWorkspaceAdmin(workspaceUser?.role)) {
+    throw new TRPCError({ code: 'FORBIDDEN' });
+  }
+}
 
 function buildWorkerOpenapi(meta: OpenApiMetaInfo): OpenApiMeta {
   return {

--- a/src/server/trpc/routers/workspace.ts
+++ b/src/server/trpc/routers/workspace.ts
@@ -236,6 +236,7 @@ export const workspaceRouter = router({
             user: z.object({
               username: z.string(),
               nickname: z.string().nullable(),
+              avatar: z.string().nullable(),
               email: z.string().nullable(),
               emailVerified: z.date().nullable(),
             }),
@@ -255,6 +256,7 @@ export const workspaceRouter = router({
             select: {
               username: true,
               nickname: true,
+              avatar: true,
               email: true,
               emailVerified: true,
             },


### PR DESCRIPTION
## Background
Workers needed a way to separate who created them from who can maintain them. This lets a workspace admin assign a worker owner, and that owner can edit or test the worker even without full admin permissions.

## Changes
- Add creator, owner, and revision operator fields to worker database models.
- Allow admins to assign worker owners from workspace members.
- Let worker owners edit, save, test, toggle, and roll back their own workers.
- Show creator, owner, and revision operator identity in worker UI.
- Add shared user select UI for choosing worker owners.

## Testing
Patch includes component tests for `UserSelect` and worker owner form behavior, plus server tests for owner authorization, revision operators, worker profiles, and cron manager revision metadata.